### PR TITLE
Add expiration and sender/amount validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,444 @@ Unexpected parameter type: ..
 ExitFailure 1
 ```
 
+
+## Validated Expiring Forwarder Contract
+
+# Intro
+
+## Originating the contract
+
+The CLI `print-validated-expiring` command accepts `--help`:
+
+```bash
+❯❯❯ ./stack exec -- dstoken-forwarder-contract print-validated-expiring --help
+
+Usage: dstoken-forwarder-contract print-validated-expiring --central-wallet ADDRESS
+                                                           --dstoken-address ADDRESS
+                                                           [-o|--output FILEPATH]
+                                                           [--oneline]
+  Dump DS Token Forwarder contract, specialized to paricular addresses, with
+  sender validating and expiration, in the form of Michelson code
+
+Available options:
+  -h,--help                Show this help text
+  --central-wallet ADDRESS Address of central wallet
+  --dstoken-address ADDRESS
+                           Address of DS Token contract
+  -o,--output FILEPATH     Output file
+  --oneline                Force single line output
+```
+
+We'll set the `central-wallet` address and `dstoken-address` to `$ALICE_ADDRESS`
+for testing:
+
+```bash
+❯❯❯ ./stack exec -- dstoken-forwarder-contract print-validated-expiring \
+  --central-wallet $ALICE_ADDRESS \
+  --dstoken-address $ALICE_ADDRESS \
+  --oneline
+```
+
+Next, we'll need to specify the initial storage:
+
+```bash
+❯❯❯ ./stack exec -- dstoken-forwarder-contract initial-storage-validated-expiring --help
+
+Usage: dstoken-forwarder-contract initial-storage-validated-expiring --dstoken-address ADDRESS
+                                                                     --whitelisted-investors [STRING]
+                                                                     --token-limit NATURAL
+                                                                     --expiration-date TIMESTAMP
+                                                                     [-o|--output FILEPATH]
+  Dump initial storage value for validated-expiring forwarder
+
+Available options:
+  -h,--help                Show this help text
+  --dstoken-address ADDRESS
+                           Address of DS Token contract
+  --whitelisted-investors [STRING]
+                           List of Strings representing whitelisted-investors.
+  --token-limit NATURAL    Natural number representing token-limit.
+  --expiration-date TIMESTAMP
+                           Timestamp number representing expiration-date.
+  -o,--output FILEPATH     Output file
+```
+
+We'll set:
+- `token-limit` (the total number of tokens that can be forwarded) to `10`
+- `expiration-date` to `9:00 next Fri`, UTC
+
+```bash
+❯❯❯ ./stack exec -- dstoken-forwarder-contract initial-storage-validated-expiring \
+  --dstoken-address $ALICE_ADDRESS \
+  --whitelisted-investors '["alice"]' \
+  --token-limit 10 \
+  --expiration-date "$(date -u -d '9:00 next Fri' +%FT%T.%NZ)"
+
+Pair (Pair Unit (Pair "tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr" (Pair { "alice" } 10))) "2020-01-10T09:00:00Z"
+```
+
+Then, we can originate the forwarder:
+
+```bash
+❯❯❯ alpha-client --wait none originate contract ValidatedForwarder \
+  transferring 0 from $ALICE_ADDRESS running \
+  "$(./stack exec -- dstoken-forwarder-contract print-validated-expiring \
+  --central-wallet $ALICE_ADDRESS \
+  --dstoken-address $ALICE_ADDRESS \
+  --oneline)" --init "$(./stack exec -- dstoken-forwarder-contract \
+  initial-storage-validated-expiring \
+  --dstoken-address $ALICE_ADDRESS \
+  --whitelisted-investors '["alice"]' \
+  --token-limit 10 \
+  --expiration-date "$(date -u -d '9:00 next Fri' +%FT%T.%NZ)")" \
+  --burn-cap 1.644
+
+Waiting for the node to be bootstrapped before injection...
+Current head: BMDM2fLkz7A9 (timestamp: 2020-01-06T21:13:14-00:00, validation: 2020-01-06T21:13:35-00:00)
+Node is bootstrapped, ready for injecting operations.
+Estimated gas: 47154 units (will add 100 for safety)
+Estimated storage: 1644 bytes added (will add 20 for safety)
+Operation successfully injected in the node.
+Operation hash is 'oo5xbTawimvR81VNayeXr5redRtJhCZGKRjRwcCct4Wqxk9xdj2'
+NOT waiting for the operation to be included.
+Use command
+  tezos-client wait for oo5xbTawimvR81VNayeXr5redRtJhCZGKRjRwcCct4Wqxk9xdj2 to be included --confirmations 30 --branch BMDM2fLkz7A9j4TSBpH2YdRoofH9qbcCYLG3JbX399MRm17mM8y
+and/or an external block explorer to make sure that it has been included.
+This sequence of operations was run:
+  Manager signed operations:
+    From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+    Fee to the baker: ꜩ0.006376
+    Expected counter: 69251
+    Gas limit: 47254
+    Storage limit: 1664 bytes
+    Balance updates:
+      tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr ............ -ꜩ0.006376
+      fees(tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU,92) ... +ꜩ0.006376
+    Origination:
+      From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+      Credit: ꜩ0
+      Script:
+        { parameter
+            (or (or nat
+                    (or (or (pair nat string) (pair unit (contract address)))
+                        (or (pair unit (contract nat)) (pair unit (contract (set string))))))
+                (pair unit (contract timestamp))) ;
+          storage (pair (pair unit (pair address (pair (set string) nat))) timestamp) ;
+          code { DUP ;
+                 CAR ;
+                 DIP { CDR } ;
+                 IF_LEFT
+                   { DIP { DUP ;
+                           CAR ;
+                           DIP { CDR } ;
+                           DIP { DUP ; NOW ; COMPARE ; LT ; IF {} { PUSH string "expired" ; FAILWITH } } } ;
+                     PAIR ;
+                     SWAP ;
+                     DIP { DUP ;
+                           CAR ;
+                           DIP { CDR } ;
+                           IF_LEFT
+                             { DIP { DUP ; CAR ; DIP { CDR } } ;
+                               PAIR ;
+                               SWAP ;
+                               DIP { CAR ;
+                                     PUSH address "tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr" ;
+                                     PAIR ;
+                                     DIP { PUSH (or unit unit) (Right Unit) } ;
+                                     PAIR ;
+                                     PACK ;
+                                     PUSH string "callTokenTransfer" ;
+                                     PAIR ;
+                                     LEFT (pair nat
+                                                (pair (lambda (big_map bytes bytes) (big_map bytes bytes))
+                                                      (lambda
+                                                         (pair (pair string bytes) (big_map bytes bytes))
+                                                         (pair (list operation) (big_map bytes bytes))))) ;
+                                     LEFT (or (pair unit (contract nat)) address) ;
+                                     LEFT (or (or nat (lambda (big_map bytes bytes) (big_map bytes bytes)))
+                                              (or (lambda
+                                                     (pair (pair string bytes) (big_map bytes bytes))
+                                                     (pair (list operation) (big_map bytes bytes)))
+                                                  unit)) ;
+                                     DIP { PUSH address "tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr" ;
+                                           CONTRACT
+                                             (or (or (or (pair string bytes)
+                                                         (pair nat
+                                                               (pair (lambda (big_map bytes bytes) (big_map bytes bytes))
+                                                                     (lambda
+                                                                        (pair (pair string bytes) (big_map bytes bytes))
+                                                                        (pair (list operation) (big_map bytes bytes))))))
+                                                     (or (pair unit (contract nat)) address))
+                                                 (or (or nat (lambda (big_map bytes bytes) (big_map bytes bytes)))
+                                                     (or (lambda
+                                                            (pair (pair string bytes) (big_map bytes bytes))
+                                                            (pair (list operation) (big_map bytes bytes)))
+                                                         unit))) ;
+                                           IF_NONE { PUSH string "Internal: not DS" ; FAILWITH } { PUSH mutez 0 } } ;
+                                     TRANSFER_TOKENS ;
+                                     DIP { NIL operation } ;
+                                     CONS ;
+                                     DIP { UNIT } ;
+                                     PAIR ;
+                                     DUP ;
+                                     CAR ;
+                                     DIP { CDR } } ;
+                               SWAP ;
+                               DIP { SWAP ; PAIR } ;
+                               PAIR }
+                             { DIP { DUP ; CAR ; DIP { CDR } ; SWAP } ;
+                               PAIR ;
+                               SWAP ;
+                               DIP { DUP ;
+                                     CAR ;
+                                     DIP { CDR } ;
+                                     IF_LEFT
+                                       { IF_LEFT
+                                           { DIP { DUP ;
+                                                   CAR ;
+                                                   DIP { CDR } ;
+                                                   DUP ;
+                                                   SENDER ;
+                                                   COMPARE ;
+                                                   EQ ;
+                                                   IF {} { PUSH string "not DS" ; FAILWITH } ;
+                                                   SWAP ;
+                                                   DUP ;
+                                                   CAR ;
+                                                   DIP { CDR } } ;
+                                             DUP ;
+                                             CAR ;
+                                             DIP { CDR } ;
+                                             DIP { DIP { DUP } ;
+                                                   MEM ;
+                                                   IF {} { PUSH string "not in whitelist" ; FAILWITH } ;
+                                                   SWAP } ;
+                                             SWAP ;
+                                             SUB ;
+                                             ISNAT ;
+                                             IF_NONE { PUSH string "token limit exceeded" ; FAILWITH } {} ;
+                                             SWAP ;
+                                             PAIR ;
+                                             SWAP ;
+                                             PAIR ;
+                                             NIL operation ;
+                                             PAIR }
+                                           { DUP ;
+                                             CAR ;
+                                             DIP { CDR } ;
+                                             DIP { DIP { DUP } ; SWAP } ;
+                                             PAIR ;
+                                             CDR ;
+                                             CAR ;
+                                             DIP { AMOUNT } ;
+                                             TRANSFER_TOKENS ;
+                                             NIL operation ;
+                                             SWAP ;
+                                             CONS ;
+                                             PAIR } }
+                                       { IF_LEFT
+                                           { DUP ;
+                                             CAR ;
+                                             DIP { CDR } ;
+                                             DIP { DIP { DUP } ; SWAP } ;
+                                             PAIR ;
+                                             CDR ;
+                                             CDR ;
+                                             CDR ;
+                                             DIP { AMOUNT } ;
+                                             TRANSFER_TOKENS ;
+                                             NIL operation ;
+                                             SWAP ;
+                                             CONS ;
+                                             PAIR }
+                                           { DUP ;
+                                             CAR ;
+                                             DIP { CDR } ;
+                                             DIP { DIP { DUP } ; SWAP } ;
+                                             PAIR ;
+                                             CDR ;
+                                             CDR ;
+                                             CAR ;
+                                             DIP { AMOUNT } ;
+                                             TRANSFER_TOKENS ;
+                                             NIL operation ;
+                                             SWAP ;
+                                             CONS ;
+                                             PAIR } } ;
+                                     DUP ;
+                                     CAR ;
+                                     DIP { CDR } } ;
+                               SWAP ;
+                               DIP { PAIR } ;
+                               PAIR } ;
+                           DUP ;
+                           CAR ;
+                           DIP { CDR } } ;
+                     SWAP ;
+                     DIP { SWAP ; PAIR } ;
+                     PAIR }
+                   { DUP ;
+                     CAR ;
+                     DIP { CDR } ;
+                     DIP { DIP { DUP } ; SWAP } ;
+                     PAIR ;
+                     CDR ;
+                     CDR ;
+                     DIP { AMOUNT } ;
+                     TRANSFER_TOKENS ;
+                     NIL operation ;
+                     SWAP ;
+                     CONS ;
+                     PAIR } } }
+        Initial storage:
+          (Pair (Pair Unit (Pair "tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr" (Pair { "alice" } 10)))
+                "2020-01-10T09:00:00Z")
+        No delegate for this contract
+        This origination was successfully applied
+        Originated contracts:
+          KT1LsyN1fsk6aFjwWFUvfcrP9qbcgdea4zZY
+        Storage size: 1387 bytes
+        Paid storage size diff: 1387 bytes
+        Consumed gas: 47154
+        Balance updates:
+          tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr ... -ꜩ1.387
+          tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr ... -ꜩ0.257
+
+New contract KT1LsyN1fsk6aFjwWFUvfcrP9qbcgdea4zZY originated.
+Contract memorized as ValidatedForwarder.
+```
+
+Set an alias for the resulting address:
+
+```bash
+VFORWARDER_ADDRESS="KT1LsyN1fsk6aFjwWFUvfcrP9qbcgdea4zZY"
+```
+
+We can then fetch the initial storage:
+
+```bash
+❯❯❯ alpha-client get contract storage for $VFORWARDER_ADDRESS
+
+Pair (Pair Unit (Pair "tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr" (Pair { "alice" } 10)))
+     "2020-01-10T09:00:00Z"
+```
+
+
+### Validating transfers
+
+An example of an invalid transfer:
+
+```bash
+❯❯❯ ./stack exec -- dstoken-forwarder-contract validate-transfer --received-amount 3 --from-user "bob"
+Left (Right (Left (Left (Pair 3 "bob"))))
+```
+
+Submitting the validation:
+
+```bash
+❯❯❯ alpha-client --wait none transfer 0 from $ALICE_ADDRESS to $VFORWARDER_ADDRESS \
+  --arg "$(./stack exec -- dstoken-forwarder-contract validate-transfer \
+  --received-amount 3 \
+  --from-user "bob")" \
+  --burn-cap 0.000001 --dry-run
+
+Waiting for the node to be bootstrapped before injection...
+Current head: BKzQZctoHxy4 (timestamp: 2020-01-06T21:27:36-00:00, validation: 2020-01-06T21:28:20-00:00)
+Node is bootstrapped, ready for injecting operations.
+This simulation failed:
+  Manager signed operations:
+    From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+    Fee to the baker: ꜩ0
+    Expected counter: 69272
+    Gas limit: 800000
+    Storage limit: 60000 bytes
+    Transaction:
+      Amount: ꜩ0
+      From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+      To: KT1LsyN1fsk6aFjwWFUvfcrP9qbcgdea4zZY
+      Parameter: (Left (Right (Left (Left (Pair 3 "bob")))))
+      This operation FAILED.
+
+Runtime error in contract KT1LsyN1fsk6aFjwWFUvfcrP9qbcgdea4zZY:
+  001: { parameter
+  002:     (or (or nat
+  ..
+  171:              CONS ;
+  172:              PAIR } } }
+At line 94 characters 84 to 92,
+script reached FAILWITH instruction
+with "not in whitelist"
+```
+
+We then see that the storage is the same:
+
+```bash
+❯❯❯ alpha-client get contract storage for $VFORWARDER_ADDRESS
+
+Pair (Pair Unit (Pair "tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr" (Pair { "alice" } 10)))
+     "2020-01-10T09:00:00Z"
+```
+
+
+An example of a valid transfer:
+
+```bash
+❯❯❯ ./stack exec -- dstoken-forwarder-contract validate-transfer --received-amount 3 --from-user "alice"
+Left (Right (Left (Left (Pair 3 "alice"))))
+```
+
+Submitting the validation:
+
+```bash
+❯❯❯ alpha-client --wait none transfer 0 from $ALICE_ADDRESS to $VFORWARDER_ADDRESS \
+  --arg "$(./stack exec -- dstoken-forwarder-contract validate-transfer \
+  --received-amount 3 \
+  --from-user "alice")" \
+  --burn-cap 0.000001
+
+Waiting for the node to be bootstrapped before injection...
+Current head: BKk59cCQzKhR (timestamp: 2020-01-06T21:31:16-00:00, validation: 2020-01-06T21:31:27-00:00)
+Node is bootstrapped, ready for injecting operations.
+Estimated gas: 41869 units (will add 100 for safety)
+Estimated storage: no bytes added
+Operation successfully injected in the node.
+Operation hash is 'ooCSRY7f9mWRjJDg1iQ8EYaQiDRXxGnJtfRZbGNibM6n4n6EgPv'
+NOT waiting for the operation to be included.
+Use command
+  tezos-client wait for ooCSRY7f9mWRjJDg1iQ8EYaQiDRXxGnJtfRZbGNibM6n4n6EgPv to be included --confirmations 30 --branch BKk59cCQzKhRfV3FUdCo9pd86pzgq6jufRJuPgktLgDN2Nih1rk
+and/or an external block explorer to make sure that it has been included.
+This sequence of operations was run:
+  Manager signed operations:
+    From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+    Fee to the baker: ꜩ0.004475
+    Expected counter: 69277
+    Gas limit: 41969
+    Storage limit: 0 bytes
+    Balance updates:
+      tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr ............ -ꜩ0.004475
+      fees(tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU,92) ... +ꜩ0.004475
+    Transaction:
+      Amount: ꜩ0
+      From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+      To: KT1LsyN1fsk6aFjwWFUvfcrP9qbcgdea4zZY
+      Parameter: (Left (Right (Left (Left (Pair 3 "alice")))))
+      This transaction was successfully applied
+      Updated storage:
+        (Pair (Pair Unit
+                    (Pair 0x00003b5d4596c032347b72fb51f688c45200d0cb50db (Pair { "alice" } 7)))
+              1578646800)
+      Storage size: 1387 bytes
+      Consumed gas: 41869
+```
+
+And then we can check that the storage is properly updated (reducing the
+`token-limit` from `10` to `7`):
+
+
+```bash
+❯❯❯ alpha-client get contract storage for $VFORWARDER_ADDRESS
+
+Pair (Pair Unit (Pair "tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr" (Pair { "alice" } 7)))
+     "2020-01-10T09:00:00Z"
+```
+

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,7 @@ dependencies:
 - morley-ledgers
 - morley-upgradeable
 - constraints
-
+- containers
 - morley-dstoken
 - vinyl
 
@@ -52,7 +52,6 @@ executables:
     - fmt
     - optparse-applicative
     - universum
-    - containers
 
 tests:
   prototype-forwarder-contract-test:

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 001775dbe982faf6a91a04212dc95fc368691ccb1398629f7516b8c66c652d34
+-- hash: a702fe8f6d53e685eb74996988a1496794f6933ea5c1ed0e87b8f945e375a449
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -27,9 +27,14 @@ source-repository head
 
 library
   exposed-modules:
+      Lorentz.Contracts.Expiring
       Lorentz.Contracts.Forwarder
       Lorentz.Contracts.Forwarder.DS.V1
       Lorentz.Contracts.Forwarder.DS.V1.Specialized
+      Lorentz.Contracts.Forwarder.DS.V1.ValidatedExpiring
+      Lorentz.Contracts.Product
+      Lorentz.Contracts.Validate.Reception
+      Lorentz.Contracts.View
   other-modules:
       Paths_prototype_forwarder_contract
   hs-source-dirs:

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a702fe8f6d53e685eb74996988a1496794f6933ea5c1ed0e87b8f945e375a449
+-- hash: a57e1a4f27cb746c7e33bbb8479d237c5540df5ed4c4bec17b0472b1b2ba2d2a
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -42,6 +42,7 @@ library
   build-depends:
       base >=4.7 && <5
     , constraints
+    , containers
     , morley
     , morley-dstoken
     , morley-ledgers
@@ -88,6 +89,7 @@ test-suite prototype-forwarder-contract-test
   build-depends:
       base >=4.7 && <5
     , constraints
+    , containers
     , morley
     , morley-dstoken
     , morley-ledgers

--- a/src/Lorentz/Contracts/Expiring.hs
+++ b/src/Lorentz/Contracts/Expiring.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS -Wall -Wno-unused-do-bind -Wno-orphans #-}
+
+module Lorentz.Contracts.Expiring where
+
+import Prelude hiding ((>>), drop)
+import GHC.Generics (Generic) -- , Generic1)
+import Text.Show (Show(..))
+import Data.Functor.Classes
+import Text.Read (Read(..))
+import Text.ParserCombinators.ReadPrec
+
+import Lorentz
+import Michelson.Text
+import Michelson.Typed.EntryPoints
+
+-- | Uses `parseEpAddress` with the remainder of the input
+instance Read EpAddress where
+  readPrec = do
+    eEpAddress <- parseEpAddress . fromString <$> look
+    case eEpAddress of
+      Left err -> fail $ show err
+      Right epAddress' -> return epAddress'
+
+-- | Uses `readBinaryWith`
+instance (Read a, NiceParameter r) => Read (View a r) where
+  readPrec = readBinaryWith readPrec readPrec "View" $
+    (\x -> View x . toContractRef @r @EpAddress)
+
+-- | Either a `WrappedParameter`, which will fail if the contract has expired,
+-- or `GetExpiration` (will never fail).
+data Parameter cp
+  = WrappedParameter !cp
+  | GetExpiration (View () Timestamp)
+  deriving  (Generic)
+
+-- (NiceParameter cp, HasNoOp (ToT cp), HasNoNestedBigMaps (ToT cp))
+instance NiceParameter cp => ParameterEntryPoints (Parameter cp) where
+  parameterEntryPoints = pepNone
+
+deriving instance Read cp => Read (Parameter cp)
+
+deriving instance Show cp => Show (Parameter cp)
+
+deriving instance IsoValue cp => IsoValue (Parameter cp)
+
+data Storage st = Storage
+  { wrappedStorage :: !st
+  , expirationTime :: !Timestamp
+  }
+  deriving  (Generic)
+
+-- | `coerce_` from `Storage`
+unStorage :: Storage st & s :-> (st, Timestamp) & s
+unStorage = coerce_
+
+-- | `coerce_` to `Storage`
+toStorage :: (st, Timestamp) & s :-> Storage st & s
+toStorage = coerce_
+
+deriving instance Show st => Show (Storage st)
+
+deriving instance IsoValue st => IsoValue (Storage st)
+
+-- | If the `Timestamp` is not before `now`, throws @"expired"@.
+--
+-- Caveat: `now` does not return the current time, it returns
+-- the timestamp of the last baked block. This means that
+-- `now` can be up to @time_between_blocks@ behind realtime.
+--
+-- Currently, @time_between_blocks@ is @60 seconds@ on mainnet
+-- or @30@ seconds on testnet.
+assertNotExpired :: Timestamp & s :-> Timestamp & s
+assertNotExpired = do
+  dup
+  now
+  assertLt $ mkMTextUnsafe "expired"
+
+-- | Adds non-changeable expiration to a contract:
+--
+-- `Storage` contains an expiration `Timestamp` that can be
+-- queried using `GetExpiration`.
+--
+-- Once the `Timestamp` is past, the contract is locked
+--
+-- Caveat: Up to error due to `now`, see `assertNotExpired` for more info
+expiringContract :: forall cp st. IsoValue cp
+  => Contract cp st
+  -> Contract (Parameter cp) (Storage st)
+expiringContract wrappedContract = do
+  unpair
+  caseT @(Parameter cp)
+    ( #cWrappedParameter /-> do
+        dip $ do
+          unStorage
+          unpair
+          dip assertNotExpired
+        pair
+        swap
+        dip $ do
+          wrappedContract
+          unpair
+        swap
+        dip $ do
+          swap
+          pair
+          toStorage
+        pair
+    , #cGetExpiration /-> view_ $ do
+        cdr
+        unStorage
+        cdr
+    )
+

--- a/src/Lorentz/Contracts/Expiring.hs
+++ b/src/Lorentz/Contracts/Expiring.hs
@@ -23,16 +23,12 @@
 module Lorentz.Contracts.Expiring where
 
 import Prelude hiding ((>>), drop)
-import GHC.Generics (Generic) -- , Generic1)
+import GHC.Generics (Generic)
 import Text.Show (Show(..))
-import Data.Functor.Classes
 import Text.Read (Read(..))
--- import Text.ParserCombinators.ReadPrec
 
 import Lorentz
 import Michelson.Text
-import Michelson.Typed.EntryPoints
-import Tezos.Address
 
 import Lorentz.Contracts.View
 

--- a/src/Lorentz/Contracts/Forwarder/DS/V1.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1.hs
@@ -25,8 +25,6 @@ import Michelson.Text
 import Michelson.Typed.T
 import Lorentz
 import qualified Lorentz.Contracts.Upgradeable.Common as Upgradeable
--- import Michelson.Typed.Haskell.Instr.Sum
--- import Michelson.Typed.Haskell.Value
 import Michelson.Typed.Value
 import Michelson.Typed.Instr (Instr)
 import Michelson.Analyzer (AnalyzerRes)
@@ -45,10 +43,6 @@ instance IsoValue (Value' Instr a) where
   type ToT (Value' Instr a) = a
   toVal = id
   fromVal = id
-
--- deriving instance (Show a, Show r) => Show (View a r)
--- deriving instance Show a => Show (ContractAddr a)
--- deriving instance Show (Upgradeable.Parameter entries)
 
 -- | Construct a 'UParam' safely. See `mkUParam`.
 toUParam
@@ -75,7 +69,6 @@ data Storage = Storage
   , centralWallet :: Address
   }
   deriving stock Eq
-  -- deriving stock Show
   deriving stock Generic
   deriving anyclass IsoValue
 
@@ -141,11 +134,6 @@ forwarderContract = do
   dip nil
   cons
   pair
-
--- forwarderCompilationWay :: LorentzCompilationWay Parameter Storage
--- forwarderCompilationWay = lcwDumb
-
--- forwarderDocumentation :: LText
 
 analyzeForwarder :: AnalyzerRes
 analyzeForwarder = analyzeLorentz forwarderContract

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
@@ -84,14 +84,6 @@ specializedForwarderContract centralWalletAddr' contractAddr' = do
   dip unit
   pair
 
--- -- specializedForwarderCompilationWay :: LorentzCompilationWay Parameter Storage
--- specializedForwarderCompilationWay :: (KnownValue cp, NoOperation cp, NoBigMap cp, ProperStorageBetterErrors (ToT st), IsoValue st)
---                                    => LorentzCompilationWay cp st
--- specializedForwarderCompilationWay =
---   LorentzCompilationWay (toFullContract . optimize . compileLorentzContract)
-
--- forwarderDocumentation :: LText
-
 analyzeSpecializedForwarder :: Address -> ContractRef DS.Parameter -> AnalyzerRes
 analyzeSpecializedForwarder centralWalletAddr' contractAddr' =
   analyzeLorentz $ specializedForwarderContract centralWalletAddr' contractAddr'
@@ -123,7 +115,6 @@ verifyForwarderContract centralWalletAddr' dsTokenContractRef' (SomeContract (co
     expectedContract =
       printLorentzContract
            forceOneline
-           -- specializedForwarderCompilationWay
            (specializedForwarderContract
               centralWalletAddr'
               dsTokenContractRef')

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/ValidatedExpiring.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/ValidatedExpiring.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TypeOperators #-}
+
+module Lorentz.Contracts.Forwarder.DS.V1.ValidatedExpiring where
+
+import Lorentz
+import qualified Lorentz.Contracts.Expiring as Expiring
+import qualified Lorentz.Contracts.Forwarder.DS.V1.Specialized as Forwarder
+import qualified Lorentz.Contracts.Validate.Reception as ValidateReception
+
+import Lorentz.Contracts.Product
+
+import Lorentz.Contracts.DS.V1.Registry.Types (InvestorId(..))
+import qualified Lorentz.Contracts.DS.V1 as DS
+
+
+-- | Expiring, accepts either
+-- a `Forwarder.Parameter` or a `ValidateReception.Parameter`
+type Parameter = Expiring.Parameter (Forwarder.Parameter :|: ValidateReception.Parameter)
+
+-- | Expiring, holds both the storage for
+-- `Forwarder.Storage` and `ValidateReception.Storage`
+type Storage = Expiring.Storage (Forwarder.Storage :&: ValidateReception.Storage)
+
+-- | Convenient `Storage` constructor
+mkStorage :: Address -> [InvestorId] -> Natural -> Timestamp -> Storage
+mkStorage dsTokenAddress' whitelist' tokenLimit' expirationDate' =
+  flip Expiring.Storage expirationDate' $
+    () :&: ValidateReception.mkStorage dsTokenAddress' whitelist' tokenLimit'
+
+-- | A contract that:
+-- - Expires after the given timestamp in `Expiring.Storage`
+-- - Offers a `Forwarder.specializedForwarderContract` interface
+-- - Offers a `ValidateReception.validateReceptionContract` interface
+validatedExpiringForwarder :: Address -> ContractRef DS.Parameter -> Contract Parameter Storage
+validatedExpiringForwarder centralWalletAddr' contractAddr' =
+  Expiring.expiringContract $
+  productContract
+    (Forwarder.specializedForwarderContract centralWalletAddr' contractAddr')
+    ValidateReception.validateReceptionContract
+

--- a/src/Lorentz/Contracts/Product.hs
+++ b/src/Lorentz/Contracts/Product.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+{-# OPTIONS -Wno-simplifiable-class-constraints #-}
+
+module Lorentz.Contracts.Product where
+
+import Prelude hiding ((>>), drop)
+import GHC.Generics (Generic)
+import Text.Show (Show(..))
+import Data.Functor.Classes
+import Text.Read (Read(..))
+
+import Lorentz
+import Michelson.Text
+import Michelson.Typed.EntryPoints
+import Michelson.Typed.Scope
+import Tezos.Address
+
+-- | Parameter for either given `Contract`
+data (:|:) cp1 cp2
+  = LeftParameter !cp1
+  | RightParameter !cp2
+  deriving  (Generic)
+
+instance ( NiceParameter cp1
+         , HasNoOp (ToT cp1)
+         , HasNoNestedBigMaps (ToT cp1)
+         , NiceParameter cp2
+         , HasNoOp (ToT cp2)
+         , HasNoNestedBigMaps (ToT cp2)
+         ) => ParameterEntryPoints (cp1 :|: cp2) where
+  parameterEntryPoints = pepNone
+
+deriving instance (Read cp1, Read cp2) => Read (cp1 :|: cp2)
+
+deriving instance (Show cp1, Show cp2) => Show (cp1 :|: cp2)
+
+deriving instance (IsoValue cp1, IsoValue cp2) => IsoValue (cp1 :|: cp2)
+
+-- | Parameter for both given `Contract`s
+data (:&:) st1 st2 = (:&:)
+  { leftStorage  :: !st1
+  , rightStorage :: !st2
+  }
+  deriving  (Generic)
+
+deriving instance (Read cp1, Read cp2) => Read (cp1 :&: cp2)
+
+deriving instance (Show cp1, Show cp2) => Show (cp1 :&: cp2)
+
+deriving instance (IsoValue cp1, IsoValue cp2) => IsoValue (cp1 :&: cp2)
+
+-- | `coerce_` from `(:&:)`
+unStorage :: (st1 :&: st2) & s :-> (st1, st2) & s
+unStorage = coerce_
+
+-- | `coerce_` to `(:&:)`
+toStorage :: (st1, st2) & s :-> (st1 :&: st2) & s
+toStorage = coerce_
+
+-- | The (independent) product of two contracts:
+-- accepting parameters from either (`:|:`) and holding storage
+-- for both (`:&:`)
+productContract :: forall cp1 st1 cp2 st2. (IsoValue cp1, IsoValue cp2)
+  => Contract cp1 st1
+  -> Contract cp2 st2
+  -> Contract (cp1 :|: cp2) (st1 :&: st2)
+productContract wrappedLeft wrappedRight = do
+  unpair
+  caseT @(cp1 :|: cp2)
+    ( #cLeftParameter /-> do
+        dip $ do
+          unStorage
+          unpair
+        pair
+        swap
+        dip $ do
+          wrappedLeft
+          unpair
+        swap
+        dip $ do
+          swap
+          pair
+          toStorage
+        pair
+    , #cRightParameter /-> do
+        dip $ do
+          unStorage
+          unpair
+          swap
+        pair
+        swap
+        dip $ do
+          wrappedRight
+          unpair
+        swap
+        dip $ do
+          pair
+          toStorage
+        pair
+    )
+

--- a/src/Lorentz/Contracts/Validate/Reception.hs
+++ b/src/Lorentz/Contracts/Validate/Reception.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DerivingStrategies #-}
+-- {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lorentz.Contracts.Validate.Reception where
+
+import Prelude hiding ((>>), drop)
+import GHC.Generics (Generic)
+import Text.Show (Show(..))
+-- import Data.Functor.Classes
+import Text.Read (Read(..))
+import Text.ParserCombinators.ReadPrec (look)
+
+import qualified Data.Set as Set (fromList)
+
+import Lorentz
+import Michelson.Text
+import Michelson.Typed.EntryPoints
+import Michelson.Typed.Scope
+-- import Tezos.Address
+
+import Lorentz.Contracts.View
+import Lorentz.Contracts.DS.V1.Registry.Types (InvestorId(..))
+
+instance Read MText where
+  readPrec = do
+    eMText <- mkMText . fromString <$> look
+    case eMText of
+      Left err -> fail $ show err
+      Right mText' -> return mText'
+
+deriving instance Read InvestorId
+
+-- | A `Set` of allowed senders
+type Whitelist = Set InvestorId
+
+-- | Given a `receivedAmount` and sender `InvestorId`,
+-- the `validateReceptionContract` will ensure that
+-- the `InvestorId` is in the `Whitelist` and
+-- subtract the `receivedAmount` from the `tokenLimit`.
+--
+-- If the `InvestorId` is not in the `Whitelist` or
+-- the `tokenLimit` is exceeded, the operation will fail.
+data ReceptionParameters = ReceptionParameters
+  { receivedAmount :: !Natural
+  , fromUser       :: !InvestorId
+  }
+  deriving  (Generic)
+  deriving  (Read)
+  deriving  (Show)
+  deriving  (IsoValue)
+
+-- | `coerce_` from `ReceptionParameters`
+unReceptionParameters :: ReceptionParameters & s :-> (Natural, InvestorId) & s
+unReceptionParameters = coerce_
+
+-- | For `Validate`, see `ReceptionParameters`.
+--
+-- Otherwise, offers `View_`s for its `Storage`
+data Parameter
+  = Validate !ReceptionParameters
+  | GetDSAddress !(View_ Address)
+  | GetRemaining !(View_ Natural)
+  | GetWhitelist !(View_ Whitelist)
+  deriving  (Generic)
+  deriving  (Read)
+  deriving  (Show)
+  deriving  (IsoValue)
+
+instance ParameterEntryPoints Parameter where
+  parameterEntryPoints = pepNone
+
+-- | The Address of the associated DS Token contract, a `Whitelist` of allowed
+-- sending users and how many tokens may be forwarded.
+data Storage = Storage
+  { dsTokenAddress :: !Address
+  , whitelist      :: !Whitelist
+  , tokenLimit     :: !Natural
+  }
+  deriving  (Generic)
+  deriving  (Read)
+  deriving  (Show)
+  deriving  (IsoValue)
+
+-- | `coerce_` from `Storage`
+unStorage :: Storage & s :-> (Address, (Whitelist, Natural)) & s
+unStorage = coerce_
+
+-- | `coerce_` to `Storage`
+toStorage :: (Address, (Whitelist, Natural)) & s :-> Storage & s
+toStorage = coerce_
+
+-- | Convenient `Storage` constructor
+mkStorage :: Address -> [InvestorId] -> Natural -> Storage
+mkStorage dsTokenAddress' whitelist' tokenLimit' =
+  Storage
+    dsTokenAddress'
+    (Set.fromList whitelist')
+    tokenLimit'
+
+-- | Assert that the `sender` is the given DS Token address
+assertDSIsCaller :: Address & s :-> Address & s
+assertDSIsCaller = do
+  dup
+  sender
+  assertEq $ mkMTextUnsafe "not DS"
+
+-- | Assert the given `InvestorId` is in the `Whitelist`
+assertInWhitelist :: InvestorId & Whitelist & s :-> Whitelist & s
+assertInWhitelist = do
+  dip dup
+  mem
+  assert $ mkMTextUnsafe "not in whitelist"
+
+-- | Accepts @tokensToConsume, tokenLimit@ and produces a new @tokenLimit@
+-- by subtracting @tokensToConsume@ and asserting the result is non-negative
+consumeTokenLimit :: Natural & Natural & s :-> Natural & s
+consumeTokenLimit = do
+  swap
+  sub
+  isNat
+  assertSome $ mkMTextUnsafe "token limit exceeded"
+
+validateReceptionContract :: ()
+  => Contract Parameter Storage
+validateReceptionContract = do
+  unpair
+  caseT @Parameter
+    ( #cValidate /-> do
+        stackType @[ReceptionParameters, Storage]
+        dip $ do
+          unStorage
+          unpair
+          stackType @[Address, (Whitelist, Natural)]
+          assertDSIsCaller
+          swap
+          unpair
+          stackType @[Whitelist, Natural, Address]
+        unReceptionParameters
+        unpair
+        stackType @[Natural, InvestorId, Whitelist, Natural, Address]
+        dip $ do
+          assertInWhitelist
+          swap
+        stackType @[Natural, Natural, Whitelist, Address]
+        consumeTokenLimit
+        stackType @[Natural, Whitelist, Address]
+        swap
+        pair
+        swap
+        pair
+        toStorage
+        nil
+        pair
+    , #cGetDSAddress /-> viewUnit_ $ do
+        unStorage
+        car
+    , #cGetRemaining /-> viewUnit_ $ do
+        unStorage
+        cdr
+        cdr
+    , #cGetWhitelist /-> viewUnit_ $ do
+        unStorage
+        cdr
+        car
+    )
+

--- a/src/Lorentz/Contracts/View.hs
+++ b/src/Lorentz/Contracts/View.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS -Wno-simplifiable-class-constraints #-}
+
+module Lorentz.Contracts.View where
+
+import Prelude hiding ((>>))
+import Text.Read (Read(..))
+import Text.ParserCombinators.ReadPrec (look)
+import Data.Functor.Classes
+
+import Lorentz
+import Tezos.Address
+
+-- | A `View` accepting `()` as its argument
+type View_ = View ()
+
+-- | `view_` specialized to `View_`
+viewUnit_ :: NiceParameter r =>
+  (forall (s0 :: [*]). (storage & s0) :-> (r : s0))
+  -> (View_ r & (storage & s)) :-> ((List Operation, storage) & s)
+viewUnit_ f = do
+  view_ $ do
+    cdr
+    f
+
+-- | Uses `parseAddress` with the remainder of the input
+instance Read Address where
+  readPrec = do
+    eAddress <- parseAddress . fromString <$> look
+    case eAddress of
+      Left err -> fail $ show err
+      Right address' -> return address'
+
+-- | Uses `readBinaryWith`
+instance (Read a, NiceParameter r) => Read (View a r) where
+  readPrec = readBinaryWith readPrec readPrec "View" $
+    (\x -> View x . toContractRef @r @Address)
+

--- a/src/Lorentz/Contracts/View.hs
+++ b/src/Lorentz/Contracts/View.hs
@@ -23,6 +23,9 @@ import Tezos.Address
 -- | A `View` accepting `()` as its argument
 type View_ = View ()
 
+toView_ :: ToContractRef r a => a -> View_ r
+toView_ = View () . toContractRef
+
 -- | `view_` specialized to `View_`
 viewUnit_ :: NiceParameter r =>
   (forall (s0 :: [*]). (storage & s0) :-> (r : s0))


### PR DESCRIPTION
This adds:
- Expiring contract wrapper
- Sender validation contract
  * Send it a request to validate (from a presumed DS Token contract) with an `InvestorId` and the amount of tokens forwarded
  * It will update the remaining number of tokens and ensure that the `InvestorId` is whitelisted
  * If invalid, it will throw an error, rewinding any transactions including it
  * Since it doesn't have any callbacks, it can be called at any time during the transaction
- Product contract
  * Produce a contract that accepts the entrypoints from either contract and holds both their storage
- Validated forwarder:
  * https://github.com/tqtezos/prototype-forwarder-contract/compare/whitelisted-expiring?expand=1#diff-f4c0d2f16e54455e148c26b96831deab
  * It's an expiring product of the sender-validation and forwarder contracts