### PR TITLE
Specialized forwarder for ManagedLedger

### DIFF
--- a/app/NettestHelpers.hs
+++ b/app/NettestHelpers.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module NettestHelpers
+  ( genContractId
+  , originateDS
+  , originateForwarder
+  ) where
+
+import Prelude hiding (putStrLn, show, print)
+
+import Control.Monad (forM_)
+import Fmt (pretty)
+import System.Random (randomRIO)
+import Universum.Print
+import Universum.String
+
+import Lorentz (mt, Text, Address)
+import qualified Lorentz as L
+import Lorentz.Contracts.DS.Permanent (mkEmptyStorage)
+import Lorentz.Contracts.DS.Preprocess (v0Contract, v1CompiledMigration, v1UpgradeParameters)
+import qualified Lorentz.Contracts.DS.V1 as V1
+import qualified Lorentz.Contracts.DS.V1.Token as Token
+import qualified Lorentz.Contracts.Forwarder.Specialized as Fwd
+import qualified Lorentz.Contracts.Upgradeable.Common as Upg
+import Morley.Nettest
+  (AddrOrAlias(..), NettestClientConfig(..), NettestScenario, NettestT, OriginateData(..))
+import qualified Morley.Nettest as NT
+
+genContractId :: Text -> IO Text
+genContractId prefix = do
+  contractIdNum <- randomRIO @Int (1, 10000)
+  return (prefix <> show contractIdNum)
+
+mkProductionOrigParams :: L.Address -> V1.OriginationParameters
+mkProductionOrigParams master = V1.OriginationParameters
+  { opMaster = master
+  , opTokenMeta = Token.TokenMeta
+    { tmName = [mt|DS Token|]
+    , tmSymbol = [mt|DS|]
+    , tmDecimals = 18
+    }
+  , opComplianceInfo = V1.productionComplianceInfo
+  , opMaxLocksPerInvestor = 100
+  }
+
+originateDS :: Monad m => Text -> NettestT m Address
+originateDS contractId = do
+  master <- NT.resolveNettestAddr
+  let origParameters = mkProductionOrigParams master
+
+  contract <- NT.originate OriginateData
+    { odFrom = AddrResolved master
+    , odName = contractId
+    , odBalance = 0
+    , odStorage = mkEmptyStorage master
+    , odContract = v0Contract
+    }
+  forM_ (Upg.makeEpwUpgrade $ v1UpgradeParameters origParameters) $
+    NT.callFrom (AddrResolved master) (AddrResolved contract) L.DefEpName
+  NT.comment $
+    "Successfully deployed DSToken: " <>
+    pretty contractId <> " / " <> pretty contract
+  return contract
+
+originateForwarder
+  :: Monad m => Text -> Address -> Address -> NettestT m Address
+originateForwarder contractId ds centralWallet = do
+  master <- NT.resolveNettestAddr
+  contract <- NT.originate OriginateData
+    { odFrom = AddrResolved master
+    , odName = contractId
+    , odBalance = 0
+    , odStorage = ()
+    , odContract = Fwd.specializedForwarderContract centralWallet ds
+    }
+  NT.comment $
+    "Successfully deployed forwarder: " <>
+    pretty contractId <> " / " <> pretty contract
+  return contract
+ 
+

--- a/package.yaml
+++ b/package.yaml
@@ -27,10 +27,12 @@ dependencies:
 - text
 - constraints
 - morley-ledgers
+- morley-nettest
 - morley-upgradeable
 - constraints
 - containers
 - morley-dstoken
+- universum
 - vinyl
 
 library:
@@ -49,8 +51,10 @@ executables:
     - morley
     # - morley-prelude
     - morley-dstoken
+    - morley-nettest
     - fmt
     - optparse-applicative
+    - random
     - universum
 
 tests:
@@ -63,3 +67,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - prototype-forwarder-contract
+    - fmt
+    - hspec
+    - tasty
+    - tasty-hspec

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a57e1a4f27cb746c7e33bbb8479d237c5540df5ed4c4bec17b0472b1b2ba2d2a
+-- hash: 8e837a8481d08bedada0a970ac736d4b226915e7a87f556f9e930eb6be4f8913
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -32,6 +32,7 @@ library
       Lorentz.Contracts.Forwarder.DS.V1
       Lorentz.Contracts.Forwarder.DS.V1.Specialized
       Lorentz.Contracts.Forwarder.DS.V1.ValidatedExpiring
+      Lorentz.Contracts.Forwarder.Specialized
       Lorentz.Contracts.Product
       Lorentz.Contracts.Validate.Reception
       Lorentz.Contracts.View

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4d8bb970fa944e408d0818c78d0c9f77248d6d2b29c6aef2bfeeca765f85d003
+-- hash: 91102c0c1b5c7f0b214829250e846b2794b819103ae6e3bfbb7096cc6e9aecb6
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -32,6 +32,7 @@ library
       Lorentz.Contracts.Forwarder
       Lorentz.Contracts.Forwarder.DS.V1
       Lorentz.Contracts.Forwarder.DS.V1.Specialized
+      Lorentz.Contracts.Forwarder.DS.V1.Validated
       Lorentz.Contracts.Forwarder.DS.V1.ValidatedExpiring
       Lorentz.Contracts.Forwarder.Specialized
       Lorentz.Contracts.Product

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 91102c0c1b5c7f0b214829250e846b2794b819103ae6e3bfbb7096cc6e9aecb6
+-- hash: 066fb9df50eefcd3f5da3eed5078304ef8808c82ce252d19f1285c6894d8a4f7
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -35,6 +35,7 @@ library
       Lorentz.Contracts.Forwarder.DS.V1.Validated
       Lorentz.Contracts.Forwarder.DS.V1.ValidatedExpiring
       Lorentz.Contracts.Forwarder.Specialized
+      Lorentz.Contracts.Forwarder.TestScenario
       Lorentz.Contracts.Product
       Lorentz.Contracts.Validate.Reception
       Lorentz.Contracts.View
@@ -49,16 +50,19 @@ library
     , morley
     , morley-dstoken
     , morley-ledgers
+    , morley-nettest
     , morley-upgradeable
     , named
     , singletons
     , text
+    , universum
     , vinyl
   default-language: Haskell2010
 
 executable dstoken-forwarder-contract
   main-is: Main.hs
   other-modules:
+      NettestHelpers
       Paths_prototype_forwarder_contract
   hs-source-dirs:
       app
@@ -71,10 +75,12 @@ executable dstoken-forwarder-contract
     , morley
     , morley-dstoken
     , morley-ledgers
+    , morley-nettest
     , morley-upgradeable
     , named
     , optparse-applicative
     , prototype-forwarder-contract
+    , random
     , singletons
     , text
     , universum
@@ -85,6 +91,11 @@ test-suite prototype-forwarder-contract-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.Lorentz.Contracts.Forwarder.Common
+      Test.Lorentz.Contracts.Forwarder.DS
+      Test.Lorentz.Contracts.Forwarder.DS.Common
+      Test.Lorentz.Contracts.Forwarder.Specialized
+      Tree
       Paths_prototype_forwarder_contract
   hs-source-dirs:
       test
@@ -93,13 +104,19 @@ test-suite prototype-forwarder-contract-test
       base >=4.7 && <5
     , constraints
     , containers
+    , fmt
+    , hspec
     , morley
     , morley-dstoken
     , morley-ledgers
+    , morley-nettest
     , morley-upgradeable
     , named
     , prototype-forwarder-contract
     , singletons
+    , tasty
+    , tasty-hspec
     , text
+    , universum
     , vinyl
   default-language: Haskell2010

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8e837a8481d08bedada0a970ac736d4b226915e7a87f556f9e930eb6be4f8913
+-- hash: 4d8bb970fa944e408d0818c78d0c9f77248d6d2b29c6aef2bfeeca765f85d003
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -27,6 +27,7 @@ source-repository head
 
 library
   exposed-modules:
+      GHC.Natural.Orphans
       Lorentz.Contracts.Expiring
       Lorentz.Contracts.Forwarder
       Lorentz.Contracts.Forwarder.DS.V1

--- a/src/GHC/Natural/Orphans.hs
+++ b/src/GHC/Natural/Orphans.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+-- {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+-- {-# LANGUAGE KindSignatures #-}
+-- {-# LANGUAGE NoImplicitPrelude #-}
+-- {-# LANGUAGE ScopedTypeVariables #-}
+-- {-# LANGUAGE TypeApplications #-}
+-- {-# LANGUAGE DerivingStrategies #-}
+-- {-# LANGUAGE DeriveGeneric #-}
+-- {-# LANGUAGE DeriveAnyClass #-}
+-- {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
+-- {-# LANGUAGE RebindableSyntax #-}
+-- {-# LANGUAGE OverloadedLabels #-}
+-- {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+{-# OPTIONS -Wall -Wno-orphans #-}
+
+module GHC.Natural.Orphans where
+
+import GHC.Generics
+
+import Lorentz hiding (SomeContract(..))
+import Lorentz.Run (analyzeLorentz)
+import Lorentz.Base (SomeContract(..))
+import Michelson.Analyzer (AnalyzerRes)
+-- import Michelson.Optimizer
+-- import Michelson.Typed.Instr (toFullContract)
+-- import qualified Michelson.Typed.Instr as Instr
+-- import Michelson.Typed.Annotation
+-- import Michelson.Typed.Value
+-- import Michelson.Typed.Scope
+import Michelson.Typed.Value
+import Michelson.Typed.T
+-- import Michelson.TypeCheck.Types (SomeContract(..))
+import Michelson.Text
+
+import qualified Lorentz.Contracts.DS.V1 as DS
+import Lorentz.Contracts.Forwarder.DS.V1 (toTransferParameter)
+
+import Data.Type.Equality
+import Data.Typeable
+import Prelude (Enum(..), Eq(..), ($), String, show)
+import Data.Singletons (SingI)
+
+-- | Note: `from`, `to` are undefined
+instance Generic Natural where
+  type Rep Natural = Rep ()
+  from _ = error "Generic Natural: from not defined"
+  to _ = error "Generic Natural: to not defined"
+
+-- -- | Note: `from`, `to` are undefined
+-- instance Generic (Value ('Tc 'CNat)) where
+--   type Rep (Value ('Tc 'CNat)) = Rep Natural
+--   from (VC (CvNat xs)) = from xs
+--   to = VC . CvNat . to
+
+-- instance (SingI ct, Typeable ct) => ParameterHasEntryPoints (Value ('Tc ct)) where
+--   type ParameterEntryPointsDerivation (Value ('Tc ct)) = EpdNone
+  -- parameterEntryPoints = pepNone
+
+-- | Stub instance, defining @`Rep` (`Value` t)@ to be @`Rep` ()@
+instance Generic (Value t) where
+  type Rep (Value t) = Rep ()
+  from = error "Generic (Value t): from not defined"
+  to = error "Generic (Value t): to not defined"
+
+instance (SingI t) => ParameterHasEntryPoints (Value t) where
+  type ParameterEntryPointsDerivation (Value t) = EpdNone
+
+instance ParameterHasEntryPoints Natural where
+  type ParameterEntryPointsDerivation Natural = EpdNone
+  -- parameterEntryPoints = pepNone
+

--- a/src/GHC/Natural/Orphans.hs
+++ b/src/GHC/Natural/Orphans.hs
@@ -1,23 +1,10 @@
-{-# LANGUAGE OverloadedStrings #-}
--- {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeFamilies #-}
--- {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE RankNTypes #-}
--- {-# LANGUAGE KindSignatures #-}
--- {-# LANGUAGE NoImplicitPrelude #-}
--- {-# LANGUAGE ScopedTypeVariables #-}
--- {-# LANGUAGE TypeApplications #-}
--- {-# LANGUAGE DerivingStrategies #-}
--- {-# LANGUAGE DeriveGeneric #-}
--- {-# LANGUAGE DeriveAnyClass #-}
--- {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
--- {-# LANGUAGE RebindableSyntax #-}
--- {-# LANGUAGE OverloadedLabels #-}
--- {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS -Wall -Wno-orphans #-}
 
@@ -25,27 +12,11 @@ module GHC.Natural.Orphans where
 
 import GHC.Generics
 
-import Lorentz hiding (SomeContract(..))
-import Lorentz.Run (analyzeLorentz)
-import Lorentz.Base (SomeContract(..))
-import Michelson.Analyzer (AnalyzerRes)
--- import Michelson.Optimizer
--- import Michelson.Typed.Instr (toFullContract)
--- import qualified Michelson.Typed.Instr as Instr
--- import Michelson.Typed.Annotation
--- import Michelson.Typed.Value
--- import Michelson.Typed.Scope
-import Michelson.Typed.Value
-import Michelson.Typed.T
--- import Michelson.TypeCheck.Types (SomeContract(..))
-import Michelson.Text
+import Lorentz
 
-import qualified Lorentz.Contracts.DS.V1 as DS
-import Lorentz.Contracts.Forwarder.DS.V1 (toTransferParameter)
+import Lorentz.Contracts.Forwarder.DS.V1 ()
 
-import Data.Type.Equality
-import Data.Typeable
-import Prelude (Enum(..), Eq(..), ($), String, show)
+import Prelude ()
 import Data.Singletons (SingI)
 
 -- | Note: `from`, `to` are undefined
@@ -53,16 +24,6 @@ instance Generic Natural where
   type Rep Natural = Rep ()
   from _ = error "Generic Natural: from not defined"
   to _ = error "Generic Natural: to not defined"
-
--- -- | Note: `from`, `to` are undefined
--- instance Generic (Value ('Tc 'CNat)) where
---   type Rep (Value ('Tc 'CNat)) = Rep Natural
---   from (VC (CvNat xs)) = from xs
---   to = VC . CvNat . to
-
--- instance (SingI ct, Typeable ct) => ParameterHasEntryPoints (Value ('Tc ct)) where
---   type ParameterEntryPointsDerivation (Value ('Tc ct)) = EpdNone
-  -- parameterEntryPoints = pepNone
 
 -- | Stub instance, defining @`Rep` (`Value` t)@ to be @`Rep` ()@
 instance Generic (Value t) where
@@ -75,5 +36,4 @@ instance (SingI t) => ParameterHasEntryPoints (Value t) where
 
 instance ParameterHasEntryPoints Natural where
   type ParameterEntryPointsDerivation Natural = EpdNone
-  -- parameterEntryPoints = pepNone
 

--- a/src/GHC/Natural/Orphans.hs
+++ b/src/GHC/Natural/Orphans.hs
@@ -19,13 +19,17 @@ import Lorentz.Contracts.Forwarder.DS.V1 ()
 import Prelude ()
 import Data.Singletons (SingI)
 
--- | Note: `from`, `to` are undefined
+-- | Note: `from`, `to` are undefined.
+--
+-- This instance is only to placate the constraints for `ParameterHasEntryPoints`
 instance Generic Natural where
   type Rep Natural = Rep ()
   from _ = error "Generic Natural: from not defined"
   to _ = error "Generic Natural: to not defined"
 
 -- | Stub instance, defining @`Rep` (`Value` t)@ to be @`Rep` ()@
+--
+-- This instance is only to placate the constraints for `ParameterHasEntryPoints`
 instance Generic (Value t) where
   type Rep (Value t) = Rep ()
   from = error "Generic (Value t): from not defined"

--- a/src/Lorentz/Contracts/Expiring.hs
+++ b/src/Lorentz/Contracts/Expiring.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
@@ -40,8 +41,9 @@ data Parameter cp
   | GetExpiration (View_ Timestamp)
   deriving  (Generic)
 
-instance NiceParameter cp => ParameterEntryPoints (Parameter cp) where
-  parameterEntryPoints = pepNone
+instance NiceParameter cp => ParameterHasEntryPoints (Parameter cp) where
+  -- parameterEntryPoints = pepNone
+  type ParameterEntryPointsDerivation (Parameter cp) = EpdNone
 
 deriving instance Read cp => Read (Parameter cp)
 
@@ -56,13 +58,13 @@ data Storage st = Storage
   }
   deriving  (Generic)
 
--- | `coerce_` from `Storage`
+-- | `forcedCoerce_` from `Storage`
 unStorage :: Storage st & s :-> (st, Timestamp) & s
-unStorage = coerce_
+unStorage = forcedCoerce_
 
--- | `coerce_` to `Storage`
+-- | `forcedCoerce_` to `Storage`
 toStorage :: (st, Timestamp) & s :-> Storage st & s
-toStorage = coerce_
+toStorage = forcedCoerce_
 
 deriving instance Show st => Show (Storage st)
 

--- a/src/Lorentz/Contracts/Forwarder.hs
+++ b/src/Lorentz/Contracts/Forwarder.hs
@@ -21,7 +21,6 @@ module Lorentz.Contracts.Forwarder where
 
 import Lorentz
 import qualified Lorentz.Contracts.ManagedLedger as ManagedLedger
-import qualified Lorentz.Contracts.ManagedLedger.Types as ManagedLedger
 
 import Prelude (Show(..), Enum(..))
 
@@ -54,7 +53,7 @@ toTransferParams :: (Address & Address & Natural & s) :-> (ManagedLedger.Transfe
 toTransferParams = do
   dip pair
   pair
-  coerce_ @(Address, (Address, Natural)) @ManagedLedger.TransferParams
+  forcedCoerce_ @(Address, (Address, Natural)) @ManagedLedger.TransferParams
 
 -- | Run `ManagedLedger.TransferParams` with a @`ContractRef` `ManagedLedger.Parameter`@,
 -- from `Address`, to `Address`, and number of sub-tokens
@@ -81,7 +80,7 @@ toRefundParameters :: (Mutez & Storage & s) :-> (RefundParameters & Mutez & Cont
 toRefundParameters = do
   dip sender
   pair
-  coerce_ @(Mutez, Address) @RefundParameters
+  forcedCoerce_ @(Mutez, Address) @RefundParameters
   dip (do
     push (toEnum 0 :: Mutez)
     dip (getField #tezosWallet)

--- a/src/Lorentz/Contracts/Forwarder.hs
+++ b/src/Lorentz/Contracts/Forwarder.hs
@@ -25,8 +25,6 @@ import qualified Lorentz.Contracts.ManagedLedger as ManagedLedger
 import Prelude (Show(..), Enum(..))
 
 deriving instance Show ManagedLedger.Parameter
--- deriving instance (Show a, Show r) => Show (View a r)
--- deriving instance Show a => Show (ContractRef a)
 
 -- | We need the addresses of:
 -- - The sub-token contract, assumed to accept `ManagedLedger.Parameter`

--- a/src/Lorentz/Contracts/Forwarder/DS/V1.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1.hs
@@ -95,14 +95,49 @@ toTokenTransfer = do
 --  `wrap_` \@(`UParam` entries) #cRun
 -- @
 -- toParameterRun :: forall entries entries' s. (UParam entries & s) :-> (Upgradeable.Parameter entries' & s)
-toParameterRun :: forall entries s. (Upgradeable.VerParam entries & s) :-> (Upgradeable.Parameter entries & s)
+toParameterRun ::
+     forall entries s.
+     (Upgradeable.VerParam entries & s) :-> (Upgradeable.Parameter entries & s)
 toParameterRun = do
-  forcedCoerce_ @(Upgradeable.VerParam entries) @(Value ('TPair ('Tc 'CString) ('Tc 'CBytes)))
-  left @(Value ('TPair ('Tc 'CString) ('Tc 'CBytes))) @(Value ('TPair ('Tc 'CNat) ('TPair ('TLambda ('TBigMap 'CBytes ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes))) ('TLambda ('TPair ('TPair ('Tc 'CString) ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes))) ('TPair ('TList 'TOperation) ('TBigMap 'CBytes ('Tc 'CBytes)))))))
-  left @_ @(Value ('TOr ('TPair 'TUnit ('TContract ('Tc 'CNat))) ('Tc 'CAddress)))
-  left @_ @(Value ('TOr ('TOr ('Tc 'CNat) ('TLambda ('TBigMap 'CBytes ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes)))) ('TOr ('TLambda ('TPair ('TPair ('Tc 'CString) ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes))) ('TPair ('TList 'TOperation) ('TBigMap 'CBytes ('Tc 'CBytes)))) 'TUnit)))
+  forcedCoerce_
+    @(Upgradeable.VerParam entries)
+    @(Value ('TPair ('Tc 'CString) ('Tc 'CBytes)))
+  left
+    @(Value ('TPair ('Tc 'CString) ('Tc 'CBytes)))
+    @(Value
+       ('TPair
+          ('Tc 'CNat)
+          ('TPair
+             ('TLambda
+                ('TBigMap 'CBytes ('Tc 'CBytes))
+                ('TBigMap 'CBytes ('Tc 'CBytes)))
+             ('TLambda
+                ('TPair
+                   ('TPair ('Tc 'CString) ('Tc 'CBytes))
+                   ('TBigMap 'CBytes ('Tc 'CBytes)))
+                ('TPair ('TList 'TOperation) ('TBigMap 'CBytes ('Tc 'CBytes)))))))
+  left
+    @_
+    @(Value ('TOr ('TPair 'TUnit ('TContract ('Tc 'CNat))) ('Tc 'CAddress)))
+  left
+    @_
+    @(Value
+       ('TOr
+          ('TOr
+             ('Tc 'CNat)
+             ('TLambda
+                ('TBigMap 'CBytes ('Tc 'CBytes))
+                ('TBigMap 'CBytes ('Tc 'CBytes))))
+          ('TOr
+             ('TLambda
+                ('TPair
+                   ('TPair ('Tc 'CString) ('Tc 'CBytes))
+                   ('TBigMap 'CBytes ('Tc 'CBytes)))
+                ('TPair ('TList 'TOperation) ('TBigMap 'CBytes ('Tc 'CBytes))))
+             'TUnit)))
   forcedCoerce_
 
+-- | `forcedCoerce_` to `Permanent.Parameter`
 toPermanentParameter :: forall ver s. Upgradeable.Parameter ver & s :-> Permanent.Parameter ver & s
 toPermanentParameter = forcedCoerce_
 

--- a/src/Lorentz/Contracts/Forwarder/DS/V1.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1.hs
@@ -32,6 +32,7 @@ import Michelson.Analyzer (AnalyzerRes)
 import qualified Lorentz.Contracts.DS.V1 as DS
 import qualified Lorentz.Contracts.DS.V1.Registry.Types as Registry
 import qualified Lorentz.Contracts.DS.V1.Token.Types as Token
+import qualified Lorentz.Contracts.DS.Permanent as Permanent
 
 import GHC.TypeLits (KnownSymbol)
 import Prelude (Enum(..), ($), id)
@@ -56,7 +57,7 @@ toUParam label = do
   pack
   push $ labelToMText label
   pair
-  coerce_
+  forcedCoerce_
 
 -- | The number of sub-tokens to forward
 type Parameter = Natural
@@ -72,15 +73,15 @@ data Storage = Storage
   deriving stock Generic
   deriving anyclass IsoValue
 
--- | `coerce_`
+-- | `forcedCoerce_`
 toWalletId :: (Address & s) :-> (Registry.WalletId & s)
-toWalletId = coerce_
+toWalletId = forcedCoerce_
 
 -- | Convert to `Address` and amount to `Token.ParameterTransfer`
 toTokenTransfer :: (Address & Natural & s) :-> (Token.ParameterTransfer & s)
 toTokenTransfer = do
   pair
-  coerce_
+  forcedCoerce_
   dip $ do
     push $ Token.CommitRun
   pair
@@ -93,13 +94,17 @@ toTokenTransfer = do
 -- @
 --  `wrap_` \@(`UParam` entries) #cRun
 -- @
-toParameterRun :: forall entries s. (UParam entries & s) :-> (Upgradeable.Parameter entries & s)
+-- toParameterRun :: forall entries entries' s. (UParam entries & s) :-> (Upgradeable.Parameter entries' & s)
+toParameterRun :: forall entries s. (Upgradeable.VerParam entries & s) :-> (Upgradeable.Parameter entries & s)
 toParameterRun = do
-  coerce_ @(UParam entries) @(Value ('TPair ('Tc 'CString) ('Tc 'CBytes)))
+  forcedCoerce_ @(Upgradeable.VerParam entries) @(Value ('TPair ('Tc 'CString) ('Tc 'CBytes)))
   left @(Value ('TPair ('Tc 'CString) ('Tc 'CBytes))) @(Value ('TPair ('Tc 'CNat) ('TPair ('TLambda ('TBigMap 'CBytes ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes))) ('TLambda ('TPair ('TPair ('Tc 'CString) ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes))) ('TPair ('TList 'TOperation) ('TBigMap 'CBytes ('Tc 'CBytes)))))))
   left @_ @(Value ('TOr ('TPair 'TUnit ('TContract ('Tc 'CNat))) ('Tc 'CAddress)))
   left @_ @(Value ('TOr ('TOr ('Tc 'CNat) ('TLambda ('TBigMap 'CBytes ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes)))) ('TOr ('TLambda ('TPair ('TPair ('Tc 'CString) ('Tc 'CBytes)) ('TBigMap 'CBytes ('Tc 'CBytes))) ('TPair ('TList 'TOperation) ('TBigMap 'CBytes ('Tc 'CBytes)))) 'TUnit)))
-  coerce_
+  forcedCoerce_
+
+toPermanentParameter :: forall ver s. Upgradeable.Parameter ver & s :-> Permanent.Parameter ver & s
+toPermanentParameter = forcedCoerce_
 
 -- | Convert to `Address` and amount to `DS.Parameter`
 toTransferParameter :: (Address & Natural & s) :-> (DS.Parameter & s)
@@ -107,6 +112,7 @@ toTransferParameter = do
   toTokenTransfer
   toUParam #callTokenTransfer
   toParameterRun
+  toPermanentParameter
 
 -- | Run a transfer, given the amount and the `Storage`,
 -- containing the central wallet address and sub token

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
@@ -53,7 +53,7 @@ runSpecializedTransfer centralWalletAddr' (ContractRef contractAddr' _) = do
   toTransferParameter
   dip $ do
     push contractAddr'
-    contract @DS.Parameter
+    contractCalling @DS.Parameter $ Call @"Run"
     ifNone
       (failUnexpected (mkMTextUnsafe "not DS"))
       (push (toEnum 0 :: Mutez))

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
@@ -22,21 +22,10 @@
 
 module Lorentz.Contracts.Forwarder.DS.V1.Specialized where
 
-import GHC.Generics
-
 import Lorentz hiding (SomeContract(..))
 import Lorentz.Run (analyzeLorentz)
 import Lorentz.Base (SomeContract(..))
 import Michelson.Analyzer (AnalyzerRes)
--- import Michelson.Optimizer
--- import Michelson.Typed.Instr (toFullContract)
--- import qualified Michelson.Typed.Instr as Instr
--- import Michelson.Typed.Annotation
--- import Michelson.Typed.Value
--- import Michelson.Typed.Scope
-import Michelson.Typed.Value
-import Michelson.Typed.T
--- import Michelson.TypeCheck.Types (SomeContract(..))
 import Michelson.Text
 
 import qualified Lorentz.Contracts.DS.V1 as DS
@@ -45,9 +34,8 @@ import Lorentz.Contracts.Forwarder.DS.V1 (toTransferParameter)
 import Data.Type.Equality
 import Data.Typeable
 import Prelude (Enum(..), Eq(..), ($), String, show)
-import Data.Singletons (SingI)
 
-import GHC.Natural.Orphans
+import GHC.Natural.Orphans ()
 
 -- | The number of sub-tokens to forward
 type Parameter = Natural

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
@@ -22,6 +22,8 @@
 
 module Lorentz.Contracts.Forwarder.DS.V1.Specialized where
 
+import GHC.Generics
+
 import Lorentz hiding (SomeContract(..))
 import Lorentz.Run (analyzeLorentz)
 import Lorentz.Base (SomeContract(..))
@@ -32,6 +34,7 @@ import Michelson.Analyzer (AnalyzerRes)
 -- import Michelson.Typed.Annotation
 -- import Michelson.Typed.Value
 -- import Michelson.Typed.Scope
+import Michelson.Typed.Value
 import Michelson.Typed.T
 -- import Michelson.TypeCheck.Types (SomeContract(..))
 import Michelson.Text
@@ -44,6 +47,7 @@ import Data.Typeable
 import Prelude (Enum(..), Eq(..), ($), String, show)
 import Data.Singletons (SingI)
 
+import GHC.Natural.Orphans
 
 -- | The number of sub-tokens to forward
 type Parameter = Natural
@@ -53,12 +57,6 @@ type Parameter = Natural
 -- - The central wallet to transfer sub-tokens to
 type Storage = ()
 
-
-instance (SingI ct, Typeable ct) => ParameterEntryPoints (Value ('Tc ct)) where
-  parameterEntryPoints = pepNone
-
-instance ParameterEntryPoints Natural where
-  parameterEntryPoints = pepNone
 
 -- changed
 runSpecializedTransfer :: Address -> ContractRef DS.Parameter -> (Natural & s) :-> (Operation & s)
@@ -92,7 +90,7 @@ analyzeSpecializedForwarder centralWalletAddr' contractAddr' =
 -- makeI = I
 
 contractOverValue :: forall cp st. Contract cp st -> Contract (Value (ToT cp)) (Value (ToT st))
-contractOverValue x = coerce_ # x # coerce_
+contractOverValue x = forcedCoerce_ # x # forcedCoerce_
 
 verifyForwarderContract :: Address -> ContractRef DS.Parameter -> SomeContract -> Either String ()
 verifyForwarderContract centralWalletAddr' dsTokenContractRef' (SomeContract (contract' :: Contract cp st)) =

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
@@ -74,12 +74,11 @@ analyzeSpecializedForwarder :: Address -> ContractRef DS.Parameter -> AnalyzerRe
 analyzeSpecializedForwarder centralWalletAddr' contractAddr' =
   analyzeLorentz $ specializedForwarderContract centralWalletAddr' contractAddr'
 
--- makeI :: Instr.Contract a b -> Contract (Value a) (Value b)
--- makeI = I
-
 contractOverValue :: forall cp st. Contract cp st -> Contract (Value (ToT cp)) (Value (ToT st))
 contractOverValue x = forcedCoerce_ # x # forcedCoerce_
 
+-- | Verify that `SomeContract` is an instance of `specializedForwarderContract`, for some
+-- particular central wallet address and DS Token address.
 verifyForwarderContract :: Address -> ContractRef DS.Parameter -> SomeContract -> Either String ()
 verifyForwarderContract centralWalletAddr' dsTokenContractRef' (SomeContract (contract' :: Contract cp st)) =
   case eqT @(ToT cp) @(ToT Parameter) of

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/Validated.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/Validated.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE TypeOperators #-}
 
-module Lorentz.Contracts.Forwarder.DS.V1.ValidatedExpiring where
+module Lorentz.Contracts.Forwarder.DS.V1.Validated where
 
 import Data.String (IsString(..))
 
 import Lorentz
 import Michelson.Text (mkMTextUnsafe)
-import qualified Lorentz.Contracts.Expiring as Expiring
 import qualified Lorentz.Contracts.Forwarder.DS.V1.Specialized as Forwarder
 import qualified Lorentz.Contracts.Validate.Reception as ValidateReception
 
@@ -16,32 +15,29 @@ import Lorentz.Contracts.DS.V1.Registry.Types (InvestorId(..))
 import qualified Lorentz.Contracts.DS.V1 as DS
 
 
--- | Expiring, accepts either
+-- | Accepts either
 -- a `Forwarder.Parameter` or a `ValidateReception.Parameter`
-type Parameter = Expiring.Parameter (Forwarder.Parameter :|: ValidateReception.Parameter)
+type Parameter = Forwarder.Parameter :|: ValidateReception.Parameter
 
--- | Expiring, holds both the storage for
+-- | Both the storage for
 -- `Forwarder.Storage` and `ValidateReception.Storage`
-type Storage = Expiring.Storage (Forwarder.Storage :&: ValidateReception.Storage)
+type Storage = Forwarder.Storage :&: ValidateReception.Storage
 
 -- | Convenient `Storage` constructor
-mkStorage :: [InvestorId] -> Timestamp -> Storage
-mkStorage whitelist' expirationDate' =
-  flip Expiring.Storage expirationDate' $
-    () :&: ValidateReception.mkStorage whitelist'
+mkStorage :: [InvestorId] -> Storage
+mkStorage whitelist' =
+  () :&: ValidateReception.mkStorage whitelist'
 
 -- | Convenient `Storage` constructor, that also parses `InvestorId`'s
-mkStorageWithInvestorIds :: [String] -> Timestamp -> Storage
+mkStorageWithInvestorIds :: [String] -> Storage
 mkStorageWithInvestorIds whitelist' =
   mkStorage $ InvestorId . mkMTextUnsafe . fromString <$> whitelist'
 
 -- | A contract that:
--- - Expires after the given timestamp in `Expiring.Storage`
 -- - Offers a `Forwarder.specializedForwarderContract` interface
 -- - Offers a `ValidateReception.validateReceptionContract` interface
-validatedExpiringForwarderContract :: Address -> ContractRef DS.Parameter -> Contract Parameter Storage
-validatedExpiringForwarderContract centralWalletAddr' contractAddr' =
-  Expiring.expiringContract $
+validatedForwarderContract :: Address -> ContractRef DS.Parameter -> Contract Parameter Storage
+validatedForwarderContract centralWalletAddr' contractAddr' =
   productContract
     (Forwarder.specializedForwarderContract centralWalletAddr' contractAddr')
     ValidateReception.validateReceptionContract

--- a/src/Lorentz/Contracts/Forwarder/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/Specialized.hs
@@ -26,25 +26,16 @@ import Lorentz hiding (SomeContract(..))
 import Lorentz.Run (analyzeLorentz)
 import Lorentz.Base (SomeContract(..))
 import Michelson.Analyzer (AnalyzerRes)
-import Michelson.Typed.Instr (Instr)
-import Michelson.Typed.Value
-import Michelson.Typed.T
 import Michelson.Text
 
 import qualified Lorentz.Contracts.ManagedLedger as ManagedLedger
 
 import Data.Type.Equality
 import Data.Typeable
-import Prelude (Enum(..), Eq(..), ($), String, show, id)
-import Data.Singletons (SingI)
+import Prelude (Enum(..), Eq(..), ($), String, show)
 
-import GHC.Natural.Orphans
+import GHC.Natural.Orphans ()
 
-
--- instance IsoValue (Value' Instr a) where
---   type ToT (Value' Instr a) = a
---   toVal = id
---   fromVal = id
 
 -- | The number of sub-tokens to forward
 type Parameter = Natural
@@ -64,7 +55,6 @@ toTransferParameter = do
   forcedCoerce_ @(Address, (Address, Natural)) @ManagedLedger.TransferParams
   wrap_ #cTransfer
 
--- changed
 runSpecializedTransfer :: Address -> ContractRef ManagedLedger.Parameter -> (Natural & s) :-> (Operation & s)
 runSpecializedTransfer centralWalletAddr' (ContractRef contractAddr' _) = do
   push centralWalletAddr'
@@ -92,6 +82,7 @@ analyzeSpecializedForwarder :: Address -> ContractRef ManagedLedger.Parameter ->
 analyzeSpecializedForwarder centralWalletAddr' contractAddr' =
   analyzeLorentz $ specializedForwarderContract centralWalletAddr' contractAddr'
 
+-- | `forcedCoerce_` to convert parameter and storage types to their `Value` equivalents
 contractOverValue :: forall cp st. Contract cp st -> Contract (Value (ToT cp)) (Value (ToT st))
 contractOverValue x = forcedCoerce_ # x # forcedCoerce_
 

--- a/src/Lorentz/Contracts/Forwarder/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/Specialized.hs
@@ -38,10 +38,13 @@ import Data.Typeable
 import Prelude (Enum(..), Eq(..), ($), String, show, id)
 import Data.Singletons (SingI)
 
-instance IsoValue (Value' Instr a) where
-  type ToT (Value' Instr a) = a
-  toVal = id
-  fromVal = id
+import GHC.Natural.Orphans
+
+
+-- instance IsoValue (Value' Instr a) where
+--   type ToT (Value' Instr a) = a
+--   toVal = id
+--   fromVal = id
 
 -- | The number of sub-tokens to forward
 type Parameter = Natural
@@ -52,19 +55,13 @@ type Parameter = Natural
 type Storage = ()
 
 
-instance (SingI ct, Typeable ct) => ParameterEntryPoints (Value ('Tc ct)) where
-  parameterEntryPoints = pepNone
-
-instance ParameterEntryPoints Natural where
-  parameterEntryPoints = pepNone
-
 toTransferParameter :: forall s. Address & Natural & s :-> ManagedLedger.Parameter & s
 toTransferParameter = do
   pair
   self @Parameter
   address
   pair
-  coerce_ @(Address, (Address, Natural)) @ManagedLedger.TransferParams
+  forcedCoerce_ @(Address, (Address, Natural)) @ManagedLedger.TransferParams
   wrap_ #cTransfer
 
 -- changed
@@ -96,7 +93,7 @@ analyzeSpecializedForwarder centralWalletAddr' contractAddr' =
   analyzeLorentz $ specializedForwarderContract centralWalletAddr' contractAddr'
 
 contractOverValue :: forall cp st. Contract cp st -> Contract (Value (ToT cp)) (Value (ToT st))
-contractOverValue x = coerce_ # x # coerce_
+contractOverValue x = forcedCoerce_ # x # forcedCoerce_
 
 verifyForwarderContract :: Address -> ContractRef ManagedLedger.Parameter -> SomeContract -> Either String ()
 verifyForwarderContract centralWalletAddr' dsTokenContractRef' (SomeContract (contract' :: Contract cp st)) =

--- a/src/Lorentz/Contracts/Forwarder/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/Specialized.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS -Wall -Wno-unused-do-bind -Wno-orphans #-}
+
+module Lorentz.Contracts.Forwarder.Specialized where
+
+import Lorentz hiding (SomeContract(..))
+import Lorentz.Run (analyzeLorentz)
+import Lorentz.Base (SomeContract(..))
+import Michelson.Analyzer (AnalyzerRes)
+import Michelson.Typed.Instr (Instr)
+import Michelson.Typed.Value
+import Michelson.Typed.T
+import Michelson.Text
+
+import qualified Lorentz.Contracts.ManagedLedger as ManagedLedger
+
+import Data.Type.Equality
+import Data.Typeable
+import Prelude (Enum(..), Eq(..), ($), String, show, id)
+import Data.Singletons (SingI)
+
+instance IsoValue (Value' Instr a) where
+  type ToT (Value' Instr a) = a
+  toVal = id
+  fromVal = id
+
+-- | The number of sub-tokens to forward
+type Parameter = Natural
+
+-- | We have the addresses of:
+-- - The sub-token contract, assumed to accept `DS.Parameter`
+-- - The central wallet to transfer sub-tokens to
+type Storage = ()
+
+
+instance (SingI ct, Typeable ct) => ParameterEntryPoints (Value ('Tc ct)) where
+  parameterEntryPoints = pepNone
+
+instance ParameterEntryPoints Natural where
+  parameterEntryPoints = pepNone
+
+toTransferParameter :: forall s. Address & Natural & s :-> ManagedLedger.Parameter & s
+toTransferParameter = do
+  pair
+  self @Parameter
+  address
+  pair
+  coerce_ @(Address, (Address, Natural)) @ManagedLedger.TransferParams
+  wrap_ #cTransfer
+
+-- changed
+runSpecializedTransfer :: Address -> ContractRef ManagedLedger.Parameter -> (Natural & s) :-> (Operation & s)
+runSpecializedTransfer centralWalletAddr' (ContractRef contractAddr' _) = do
+  push centralWalletAddr'
+  toTransferParameter
+  dip $ do
+    push contractAddr'
+    contract @ManagedLedger.Parameter
+    ifNone
+      (failUnexpected (mkMTextUnsafe "not FA1.2"))
+      (push (toEnum 0 :: Mutez))
+  transferTokens
+
+-- | Forwarder contract: forwards the given number of sub-tokens
+-- from its own address to the central wallet.
+specializedForwarderContract :: Address -> ContractRef ManagedLedger.Parameter -> Contract Parameter Storage
+specializedForwarderContract centralWalletAddr' contractAddr' = do
+  car
+  runSpecializedTransfer centralWalletAddr' contractAddr'
+  dip nil
+  cons
+  dip unit
+  pair
+
+analyzeSpecializedForwarder :: Address -> ContractRef ManagedLedger.Parameter -> AnalyzerRes
+analyzeSpecializedForwarder centralWalletAddr' contractAddr' =
+  analyzeLorentz $ specializedForwarderContract centralWalletAddr' contractAddr'
+
+contractOverValue :: forall cp st. Contract cp st -> Contract (Value (ToT cp)) (Value (ToT st))
+contractOverValue x = coerce_ # x # coerce_
+
+verifyForwarderContract :: Address -> ContractRef ManagedLedger.Parameter -> SomeContract -> Either String ()
+verifyForwarderContract centralWalletAddr' dsTokenContractRef' (SomeContract (contract' :: Contract cp st)) =
+  case eqT @(ToT cp) @(ToT Parameter) of
+    Nothing -> Left $ "Unexpected parameter type: " <> show (typeRep (Proxy @(ToT cp)))
+    Just Refl ->
+      case eqT @(ToT st) @(ToT Storage) of
+        Nothing -> Left $ "Unexpected storage type: " <> show (typeRep (Proxy @(ToT st)))
+        Just Refl ->
+          let givenContract =
+                printLorentzContract
+                  forceOneline $
+                  contractOverValue contract'
+           in case givenContract == expectedContract of
+                True -> return ()
+                False -> Left "The contracts have the same type, but different implementations"
+  where
+    forceOneline = True
+    expectedContract =
+      printLorentzContract
+           forceOneline
+           (specializedForwarderContract
+              centralWalletAddr'
+              dsTokenContractRef')
+

--- a/src/Lorentz/Contracts/Forwarder/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/Specialized.hs
@@ -86,6 +86,8 @@ analyzeSpecializedForwarder centralWalletAddr' contractAddr' =
 contractOverValue :: forall cp st. Contract cp st -> Contract (Value (ToT cp)) (Value (ToT st))
 contractOverValue x = forcedCoerce_ # x # forcedCoerce_
 
+-- | Verify that `SomeContract` is an instance of `specializedForwarderContract`, for some
+-- particular central wallet address and DS Token address.
 verifyForwarderContract :: Address -> ContractRef ManagedLedger.Parameter -> SomeContract -> Either String ()
 verifyForwarderContract centralWalletAddr' dsTokenContractRef' (SomeContract (contract' :: Contract cp st)) =
   case eqT @(ToT cp) @(ToT Parameter) of

--- a/src/Lorentz/Contracts/Forwarder/TestScenario.hs
+++ b/src/Lorentz/Contracts/Forwarder/TestScenario.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumDecimals #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Lorentz.Contracts.Forwarder.TestScenario
+  ( runTestScenario
+  , TestScenarioParameters(..)
+  ) where
+
+import GHC.TypeLits (KnownSymbol)
+import Universum (safeHead, (?:))
+
+import qualified Lorentz as L
+import Lorentz.Constraints
+import qualified Lorentz.Contracts.DS.V1 as V1
+import Lorentz.Contracts.DS.V1.Compliance.Types
+import qualified Lorentz.Contracts.DS.V1.Token as Token
+import qualified Lorentz.Contracts.DS.V1.Registry as Registry
+import Lorentz.Contracts.DS.V1.Registry.Types
+import Lorentz.Contracts.Upgradeable.Common as Upg
+import Lorentz.Value (Label)
+import Morley.Nettest (AddrOrAlias(..), NettestT)
+import Michelson.Text (mt)
+import qualified Morley.Nettest as NT
+import Tezos.Address (Address)
+import Tezos.Core
+
+inv0, inv1 :: InvestorId
+inv0 = InvestorId [mt|r1|]
+inv1 = InvestorId [mt|r2|]
+
+country0, euCountry :: Country
+country0 = Country [mt|country|]
+euCountry = safeHead euCountries ?: error "no EU countries"
+
+attrInfo0 :: AttributeInfo
+attrInfo0 = AttributeInfo AttrStatApproved Nothing Nothing
+
+mint :: WalletId -> L.Natural -> Token.ParameterMint
+mint wallet val =
+  Token.Mint (Token.mintParamSimple wallet val, Token.CommitRun)
+
+burn :: WalletId -> L.Natural -> Token.ParameterBurn
+burn wallet val =
+  Token.Burn (Token.burnParamSimple wallet val, Token.CommitRun)
+
+
+-- | Required for achieveing worst-case gas consumption for @transfer@.
+-- This does not include 'ciForceAccredited' enabling
+ciMostChecksForTransfer :: SetComplianceInfoData
+ciMostChecksForTransfer = ComplianceInfoExt
+  { ciTotalInvestorLimit = Just $ MaybeInfinity 999
+  , ciMinUSTokens = Nothing
+  , ciMinEUTokens = Nothing
+  , ciUSInvestorLimit = Just $ MaybeInfinity 999
+  , ciUSAccreditedInvestorsLimit = Just $ MaybeInfinity 999
+  , ciNonAccreditedInvestorsLimit = Just $ MaybeInfinity 999
+  , ciMaxUSInvestorPercentage = Nothing
+  , ciFlowbackBlockExpiryDate = Just $ MaybeInfinity farFuture
+  , ciUSLockPeriod = Nothing
+  , ciNonUSLockPeriod = Nothing
+  , ciMinimumTotalInvestors = Nothing
+  , ciMinimumHoldingsPerInvestor = Nothing
+  , ciMaximumHoldingsPerInvestor = Just $ MaybeInfinity 10e18
+  , ciEURetailLimit = Just $ MaybeInfinity 999
+  , ciForceFullTransfer = Just True
+  , ciForceAccredited = Just True
+  , ciForceAccreditedUS = Just True
+  }
+
+mkRun
+  :: ( KnownSymbol name
+     , NicePackedValue arg
+     , L.LookupEntryPoint name (Upg.VerInterface ver) ~ arg
+     , L.RequireUniqueEntryPoints (Upg.VerInterface ver)
+     )
+  => Label name -> arg -> Upg.Parameter ver
+mkRun name arg = Upg.Run $ L.mkUParam name arg
+
+mkRunV1
+  :: ( KnownSymbol name
+     , NicePackedValue arg
+     , L.LookupEntryPoint name (Upg.VerInterface ver) ~ arg
+     , ver ~ V1.VersionId1
+     )
+  => Label name -> arg -> Upg.Parameter ver
+mkRunV1 = mkRun
+
+-- | 'NT.TransferData' for the default entrypoint of some contract.
+defCallData
+  :: forall cp. (Show cp, NiceParameterFull cp)
+  => Address -> (Address, cp) -> NT.TransferData
+defCallData contract (from, param) =
+  NT.TransferData
+    { tdFrom = AddrResolved from
+    , tdTo = AddrResolved contract
+    , tdAmount = 0
+    , tdEntrypoint = L.DefEpName
+    , tdParameter = param
+    }
+
+type Scenario = [NT.TransferData]
+
+compileScenario
+  :: forall m. Monad m
+  => NettestT m Scenario -> NettestT m ()
+compileScenario scenarioM = do
+  scenario <- scenarioM
+  mapM_ NT.transfer scenario
+
+data TestScenarioParameters
+  = TestScenarioParameters
+    { tspDSToken :: Address
+    , tspCentralWallet :: Address
+    , tspForwarder :: Address
+    }
+
+testScenario :: Monad m => TestScenarioParameters -> NettestT m Scenario
+testScenario TestScenarioParameters{..} = do
+  master <- NT.resolveNettestAddr
+  someone <- NT.newAddress "addr1"
+
+  let
+    ds = tspDSToken
+    fwd = tspForwarder
+    fwdWallet = WalletId fwd
+    centralWallet = WalletId tspCentralWallet
+
+    forward :: L.Natural -> NT.TransferData
+    forward tokens = defCallData fwd (someone, tokens)
+
+    dsCallData
+      :: (Address, Upg.Parameter V1.VersionId1)
+      -> NT.TransferData
+    dsCallData = defCallData ds
+
+    performTransfer :: Scenario
+    performTransfer =
+      let tokens = 10e15 in
+      [ dsCallData (master, mkRunV1 #callTokenMint (mint fwdWallet tokens))
+      , forward tokens
+      , dsCallData (master, mkRunV1 #callTokenBurn (burn centralWallet tokens))
+      ]
+
+    initRegistryMinimal :: Scenario
+    initRegistryMinimal =
+      map dsCallData
+      [ (master, mkRunV1 #callRegistry (Registry.RegisterInvestor inv0))
+      , (master, mkRunV1 #callRegistry (Registry.AddWallet (inv0, fwdWallet)))
+      , (master, mkRunV1 #callRegistry (Registry.RegisterInvestor inv1))
+      , (master, mkRunV1 #callRegistry (Registry.AddWallet (inv1, centralWallet)))
+      ]
+
+  pure $ mconcat
+    [ initRegistryMinimal
+    , performTransfer
+    ]
+
+runTestScenario
+  :: Monad m
+  => TestScenarioParameters -> NettestT m ()
+runTestScenario params = compileScenario $ testScenario params

--- a/src/Lorentz/Contracts/Product.hs
+++ b/src/Lorentz/Contracts/Product.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -38,8 +39,9 @@ instance ( NiceParameter cp1
          , NiceParameter cp2
          , HasNoOp (ToT cp2)
          , HasNoNestedBigMaps (ToT cp2)
-         ) => ParameterEntryPoints (cp1 :|: cp2) where
-  parameterEntryPoints = pepNone
+         ) => ParameterHasEntryPoints (cp1 :|: cp2) where
+  -- parameterEntryPoints = pepNone
+  type ParameterEntryPointsDerivation (cp1 :|: cp2) = EpdNone
 
 deriving instance (Read cp1, Read cp2) => Read (cp1 :|: cp2)
 
@@ -60,13 +62,13 @@ deriving instance (Show cp1, Show cp2) => Show (cp1 :&: cp2)
 
 deriving instance (IsoValue cp1, IsoValue cp2) => IsoValue (cp1 :&: cp2)
 
--- | `coerce_` from `(:&:)`
+-- | `forcedCoerce_` from `(:&:)`
 unStorage :: (st1 :&: st2) & s :-> (st1, st2) & s
-unStorage = coerce_
+unStorage = forcedCoerce_
 
--- | `coerce_` to `(:&:)`
+-- | `forcedCoerce_` to `(:&:)`
 toStorage :: (st1, st2) & s :-> (st1 :&: st2) & s
-toStorage = coerce_
+toStorage = forcedCoerce_
 
 -- | The (independent) product of two contracts:
 -- accepting parameters from either (`:|:`) and holding storage

--- a/src/Lorentz/Contracts/Validate/Reception.hs
+++ b/src/Lorentz/Contracts/Validate/Reception.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE RankNTypes #-}
@@ -61,9 +62,9 @@ data ReceptionParameters = ReceptionParameters
   deriving  (Show)
   deriving  (IsoValue)
 
--- | `coerce_` from `ReceptionParameters`
+-- | `forcedCoerce_` from `ReceptionParameters`
 unReceptionParameters :: ReceptionParameters & s :-> (Natural, InvestorId) & s
-unReceptionParameters = coerce_
+unReceptionParameters = forcedCoerce_
 
 -- | For `Validate`, see `ReceptionParameters`.
 --
@@ -78,8 +79,8 @@ data Parameter
   deriving  (Show)
   deriving  (IsoValue)
 
-instance ParameterEntryPoints Parameter where
-  parameterEntryPoints = pepNone
+instance ParameterHasEntryPoints Parameter where
+  type ParameterEntryPointsDerivation Parameter = EpdPlain -- None
 
 -- | The Address of the associated DS Token contract, a `Whitelist` of allowed
 -- sending users and how many tokens may be forwarded.
@@ -93,13 +94,13 @@ data Storage = Storage
   deriving  (Show)
   deriving  (IsoValue)
 
--- | `coerce_` from `Storage`
+-- | `forcedCoerce_` from `Storage`
 unStorage :: Storage & s :-> (Address, (Whitelist, Natural)) & s
-unStorage = coerce_
+unStorage = forcedCoerce_
 
--- | `coerce_` to `Storage`
+-- | `forcedCoerce_` to `Storage`
 toStorage :: (Address, (Whitelist, Natural)) & s :-> Storage & s
-toStorage = coerce_
+toStorage = forcedCoerce_
 
 -- | Convenient `Storage` constructor
 mkStorage :: Address -> [InvestorId] -> Natural -> Storage

--- a/src/Lorentz/Contracts/Validate/Reception.hs
+++ b/src/Lorentz/Contracts/Validate/Reception.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DerivingStrategies #-}
--- {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -19,7 +18,6 @@ module Lorentz.Contracts.Validate.Reception where
 import Prelude hiding ((>>), drop)
 import GHC.Generics (Generic)
 import Text.Show (Show(..))
--- import Data.Functor.Classes
 import Text.Read (Read(..))
 import Text.ParserCombinators.ReadPrec (look)
 
@@ -29,7 +27,6 @@ import Lorentz
 import Michelson.Text
 import Michelson.Typed.EntryPoints
 import Michelson.Typed.Scope
--- import Tezos.Address
 
 import Lorentz.Contracts.View
 import Lorentz.Contracts.DS.V1.Registry.Types (InvestorId(..))
@@ -50,9 +47,7 @@ type Whitelist = Set InvestorId
 --
 -- Otherwise, offers `View_`s for its `Storage`
 data Parameter
-  = Validate !InvestorId
-  -- | GetDSAddress !(View_ Address)
-  -- | GetRemaining !(View_ Natural)
+  = Validate !InvestorId -- throw error unless InvestorId in Whitelist
   | GetWhitelist !(View_ Whitelist)
   deriving  (Generic)
   deriving  (Read)

--- a/src/Lorentz/Contracts/View.hs
+++ b/src/Lorentz/Contracts/View.hs
@@ -18,6 +18,7 @@ import Text.ParserCombinators.ReadPrec (look)
 import Data.Functor.Classes
 
 import Lorentz
+import Lorentz.Value
 import Tezos.Address
 
 -- | A `View` accepting `()` as its argument

--- a/src/Lorentz/Contracts/View.hs
+++ b/src/Lorentz/Contracts/View.hs
@@ -24,6 +24,7 @@ import Tezos.Address
 -- | A `View` accepting `()` as its argument
 type View_ = View ()
 
+-- | Construct a `View_`
 toView_ :: ToContractRef r a => a -> View_ r
 toView_ = View () . toContractRef
 

--- a/src/Lorentz/Contracts/View.hs
+++ b/src/Lorentz/Contracts/View.hs
@@ -26,7 +26,7 @@ type View_ = View ()
 
 -- | Construct a `View_`
 toView_ :: ToContractRef r a => a -> View_ r
-toView_ = View () . toContractRef
+toView_ = mkView ()
 
 -- | `view_` specialized to `View_`
 viewUnit_ :: NiceParameter r =>
@@ -38,15 +38,15 @@ viewUnit_ f = do
     f
 
 -- | Uses `parseAddress` with the remainder of the input
-instance Read Address where
+instance Read (TAddress r) where
   readPrec = do
     eAddress <- parseAddress . fromString <$> look
     case eAddress of
       Left err -> fail $ show err
-      Right address' -> return address'
+      Right address' -> return $ toTAddress address'
 
 -- | Uses `readBinaryWith`
-instance (Read a, NiceParameter r) => Read (View a r) where
+instance (Read a, NiceParameter r, ToContractRef r (TAddress r)) => Read (View a r) where
   readPrec = readBinaryWith readPrec readPrec "View" $
-    (\x -> View x . toContractRef @r @Address)
+    (\x -> View x . toContractRef @r @(TAddress r))
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    c9c9f8b0449e81fc1e46f3786e00b2aedf2606d7 # martoon/#65-doc-collision
+    13dc88b9f17172cfde87b60fa945aada21047a9b # martoon/#65-doc-collision
   subdirs:
     - .
     - prelude
@@ -33,7 +33,7 @@ extra-deps:
 - git:
     git@github.com:tqtezos/morley-dstoken.git
   commit:
-    935ca03370ace435222eb3cd32402ee478b44d74 # 6e07d017ee81bcbc0a2e2cfbd6601c2e1b96436b # master
+    935ca03370ace435222eb3cd32402ee478b44d74 # master
   subdirs:
     - .
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.22
+resolver: lts-14.15
 
 packages:
 - .
@@ -18,17 +18,22 @@ extra-deps:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    245a2152213c9d179759d6014972227ff0ccbf96  # master
+    c9c9f8b0449e81fc1e46f3786e00b2aedf2606d7 # martoon/#65-doc-collision
   subdirs:
     - .
-    - indigo
+    - prelude
     - morley-upgradeable
     - morley-ledgers
-    - prelude
+    - morley-ledgers-test
+    - indigo
+    - morley-nettest
+- git: https://github.com/int-index/caps.git
+  commit: ab4345eabd58fc6f05d3b46bea2c5acdba3ec6f8
+
 - git:
     git@github.com:tqtezos/morley-dstoken.git
   commit:
-    6e07d017ee81bcbc0a2e2cfbd6601c2e1b96436b # master
+    935ca03370ace435222eb3cd32402ee478b44d74 # 6e07d017ee81bcbc0a2e2cfbd6601c2e1b96436b # master
   subdirs:
     - .
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    13dc88b9f17172cfde87b60fa945aada21047a9b # martoon/#65-doc-collision
+    34c9cbfa160cde0ac8e9bd92d8fc57b3844da41e # master
   subdirs:
     - .
     - prelude
@@ -31,9 +31,9 @@ extra-deps:
   commit: ab4345eabd58fc6f05d3b46bea2c5acdba3ec6f8
 
 - git:
-    git@github.com:tqtezos/morley-dstoken.git
+    git@gitlab.com:elevated-returns/morley-dstoken.git
   commit:
-    935ca03370ace435222eb3cd32402ee478b44d74 # master
+    dbfc4980249410a0df1c8c5bdf3d1dd0765d70d3 # master
   subdirs:
     - .
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,12 @@
+module Main
+  ( main
+  ) where
+
+import Test.Tasty (defaultMainWithIngredients)
+
+import Util.Test.Ingredients (ourIngredients)
+
+import Tree (tests)
+
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = tests >>= defaultMainWithIngredients ourIngredients

--- a/test/Test/Lorentz/Contracts/Forwarder/Common.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/Common.hs
@@ -1,0 +1,16 @@
+module Test.Lorentz.Contracts.Forwarder.Common
+  ( centralWallet
+  , masterAddress
+  ) where
+
+
+import Lorentz
+
+import Lorentz.Test
+
+-- | By default, we set master and admin to this address.
+masterAddress :: Address
+masterAddress = genesisAddress
+
+centralWallet :: Address
+centralWallet = genesisAddress2

--- a/test/Test/Lorentz/Contracts/Forwarder/DS.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/DS.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Lorentz.Contracts.Forwarder.DS
+  ( spec_SpecializedDSForwarder
+  , spec_ValidatedDSForwarder
+  ) where
+
+import Lorentz
+
+import Control.Monad (forM_)
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Fmt (Buildable(..), listF)
+
+import Lorentz.Contracts.DS.V1.Registry (InvestorId)
+import qualified Lorentz.Contracts.Forwarder.DS.V1.Specialized as Fwd
+import qualified Lorentz.Contracts.Forwarder.DS.V1.Validated as Validated
+import Lorentz.Contracts.Validate.Reception (Parameter(..), Whitelist)
+import Lorentz.Contracts.Product ((:|:)(..))
+import Lorentz.Test
+import Test.Hspec (Spec, describe, it)
+import Util.Named ((.!))
+
+import Test.Lorentz.Contracts.Forwarder.Common
+import Test.Lorentz.Contracts.Forwarder.DS.Common
+
+type ForwarderRef = TAddress Natural
+type ValidatedForwarderRef = TAddress Validated.Parameter
+
+originateSpecializedForwarder :: DSRef -> IntegrationalScenarioM (ForwarderRef)
+originateSpecializedForwarder dsRef =
+  lOriginate fwd "DS Specialized Forwarder" () (toMutez 0)
+  where
+    fwd = Fwd.specializedForwarderContract centralWallet (callingDefTAddress dsRef)
+
+originateValidatedForwarder
+  :: DSRef -> [InvestorId] -> IntegrationalScenarioM (ValidatedForwarderRef)
+originateValidatedForwarder dsRef investorList =
+  lOriginate fwd "DS Validated Forwarder" storage (toMutez 0)
+  where
+    storage = Validated.mkStorage investorList
+    fwd = Validated.validatedForwarderContract centralWallet (callingDefTAddress dsRef)
+
+spec_SpecializedDSForwarder :: Spec
+spec_SpecializedDSForwarder = do
+  it "Successfully forwards funds to centralWallet" $
+    integrationalTestExpectation $ do
+      dsAddr <- originateDSToken
+      fwd <- originateSpecializedForwarder dsAddr
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      registerInvestor dsAddr investor1 $
+          [(toAddress fwd), centralWallet]
+      mint dsAddr (toAddress fwd) 100500
+      lCallDef fwd (100500 :: Natural)
+      lCallEP dsAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [100500]
+
+spec_ValidatedDSForwarder :: Spec
+spec_ValidatedDSForwarder = do
+  it "Successfully forwards funds to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr [investor1]
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      registerInvestor dsAddr investor1 $
+          [(toAddress fwd), centralWallet]
+      mint dsAddr (toAddress fwd) amount
+      lCallDef fwd $ LeftParameter amount
+      lCallEP dsAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]
+
+  it "Successfully validates a whitelisted investor" $
+    integrationalTestExpectation $ do
+      let investors = [investor1, investor2]
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr investors
+      forM_ investors $ \inv ->
+        lCallDef fwd . RightParameter $ Validate inv
+      validate . Right $ expectAnySuccess
+
+  it "Fails to validate a non-whitelisted investor" $
+    integrationalTestExpectation $ do
+      let investors = [investor1, investor2]
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr investors
+      lCallDef fwd . RightParameter $ Validate investor3
+      validate . Left $ lExpectError (== [mt|not in whitelist|])
+
+  it "Returns a list of whitelisted investors" $
+    integrationalTestExpectation $ do
+      let investors = [investor1, investor2]
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr investors
+      consumer <- lOriginateEmpty @Whitelist contractConsumer "consumer"
+      lCallDef fwd . RightParameter . GetWhitelist $ mkView () consumer
+      validate . Right $
+        lExpectViewConsumerStorage consumer $ [Set.fromList investors]
+
+instance Buildable (Set InvestorId) where
+  build = listF

--- a/test/Test/Lorentz/Contracts/Forwarder/DS/Common.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/DS/Common.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Lorentz.Contracts.Forwarder.DS.Common
+  ( DSRef
+  , investor1
+  , investor2
+  , investor3
+  , mint
+  , originateDSToken
+  , registerInvestor
+  ) where
+
+
+import Control.Monad (forM_)
+import Lorentz
+
+import Data.Coerce (coerce)
+import GHC.TypeLits (KnownSymbol)
+
+import qualified Lorentz.Contracts.DS.Permanent as Permanent
+import Lorentz.Contracts.DS.Preprocess
+import Lorentz.Contracts.DS.V0 as V0
+import Lorentz.Contracts.DS.V1 as V1
+import qualified Lorentz.Contracts.DS.V1.Token as Token
+import Lorentz.Contracts.DS.V1.Registry as Registry
+import qualified Lorentz.Contracts.Upgradeable.Common as Upg
+import Lorentz.Test
+import Lorentz.UParam
+
+import Test.Lorentz.Contracts.Forwarder.Common
+
+investor1, investor2 :: Registry.InvestorId
+investor1 = Registry.InvestorId [mt|investor1|]
+investor2 = Registry.InvestorId [mt|investor2|]
+investor3 = Registry.InvestorId [mt|investor3|]
+
+maxLocksPerInvestorDefault :: Natural
+maxLocksPerInvestorDefault = 100
+
+defaultOrigParameters :: OriginationParameters
+defaultOrigParameters = OriginationParameters
+  { opMaster = masterAddress
+  , opTokenMeta = Token.dummyTokenMeta
+  , opComplianceInfo = weakestComplianceInfo
+  , opMaxLocksPerInvestor = maxLocksPerInvestorDefault
+  }
+
+dsCall
+  :: forall a name.
+  ( NicePackedValue a
+  , KnownSymbol name
+  , RequireUniqueEntryPoints V1.Interface
+  , LookupEntryPoint name V1.Interface ~ a
+  )
+  => Label name
+  -> DSRef
+  -> a
+  -> IntegrationalScenarioM ()
+dsCall method addr arg =
+  lCallDef addr $
+  Upg.Run (mkUParam method arg :: UParam V1.Interface)
+
+-- | 'TAddress' of DS protocol contract (V1).
+type DSRef = TAddress V1.Parameter
+
+-- | Originate V1 of DS Protocol with default parameters.
+originateDSToken :: IntegrationalScenarioM DSRef
+originateDSToken =
+  originateDSTokenWithParameters defaultOrigParameters
+
+-- | Originate V1 of DS Protocol with custom parameters.
+originateDSTokenWithParameters
+  :: OriginationParameters -> IntegrationalScenarioM DSRef
+originateDSTokenWithParameters origParameters = do
+  contract <- lOriginate
+    v0Contract
+    "DS Protocol"
+    (Permanent.mkEmptyStorage masterAddress)
+    (toMutez 0)
+  upgradeToV1 origParameters contract
+
+upgradeToV1 ::
+     OriginationParameters
+  -> TAddress (Upg.Parameter V0.VersionId0)
+  -> IntegrationalScenarioM DSRef
+upgradeToV1 origParameters contract =
+  -- 'coerceContractRef' is necessary because our 'Parameter' is a
+  -- newtype wrapper.
+  coerce <$>
+  Upg.integrationalTestEpwUpgrade (v1UpgradeParameters origParameters) contract
+
+registerInvestor
+    :: DSRef -> InvestorId -> [Address] -> IntegrationalScenarioM ()
+registerInvestor dsRef investor addressList = do
+  withSender masterAddress $
+    dsCall #callRegistry dsRef $ RegisterInvestor investor
+  forM_ addressList $ \address -> do
+    withSender masterAddress $
+      dsCall #callRegistry dsRef $
+        AddWallet (investor, WalletId address)
+
+mint :: DSRef -> Address -> Natural -> IntegrationalScenarioM ()
+mint dsRef beneficiary amount =
+  withSender masterAddress $
+    dsCall #callTokenMint dsRef $
+      Token.Mint (Token.mintParamSimple wallet amount, Token.CommitRun)
+  where wallet = WalletId beneficiary

--- a/test/Test/Lorentz/Contracts/Forwarder/Specialized.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/Specialized.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Lorentz.Contracts.Forwarder.Specialized
+  ( spec_SpecializedForwarder
+  ) where
+
+import Lorentz
+
+import Control.Monad (forM_)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Fmt (Buildable(..), listF)
+
+import qualified Indigo.Contracts.AbstractLedger as AL
+import qualified Lorentz.Contracts.Spec.AbstractLedgerInterface as AL
+import Lorentz.Contracts.DS.V1.Registry (InvestorId)
+import qualified Lorentz.Contracts.Forwarder.Specialized as Fwd
+import qualified Lorentz.Contracts.ManagedLedger as ML
+import Lorentz.Test
+import Test.Hspec (Spec, describe, it)
+import Util.Named ((.!))
+
+import Test.Lorentz.Contracts.Forwarder.Common
+import Test.Lorentz.Contracts.Forwarder.DS.Common
+
+type ForwarderRef = TAddress Natural
+
+originateSpecializedForwarder :: Address -> IntegrationalScenarioM (ForwarderRef)
+originateSpecializedForwarder tokenAddress =
+  lOriginate fwd "FA1.2 Specialized Forwarder" () (toMutez 0)
+  where
+    fwd = Fwd.specializedForwarderContract centralWallet tokenAddress
+
+originateAbstractLedger :: IntegrationalScenarioM (TAddress AL.Parameter)
+originateAbstractLedger =
+  lOriginate AL.abstractLedgerContract "Abstract ledger" storage (toMutez 0)
+  where
+    storage = AL.Storage
+       { AL.ledger = BigMap $ Map.fromList [(masterAddress, 100500)]
+       , AL.totalSupply = 100500
+       }
+
+originateManagedLedger :: IntegrationalScenarioM (TAddress ML.Parameter)
+originateManagedLedger =
+  lOriginate ML.managedLedgerContract "Managed ledger"
+    (ML.mkStorage masterAddress mempty) (toMutez 0)
+
+spec_SpecializedForwarder :: Spec
+spec_SpecializedForwarder = do
+  it "Successfully forwards Abstract ledger tokens to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      tokenAddr <- originateAbstractLedger
+      fwd <- originateSpecializedForwarder $ toAddress tokenAddr
+      withSender masterAddress . lCallDef tokenAddr $
+          AL.Transfer
+          ( #from .! masterAddress
+          , #to .! toAddress fwd
+          , #value .! amount
+          )
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      lCallDef fwd amount
+      lCallEP tokenAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]
+
+  it "Successfully forwards Managed ledger tokens to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      tokenAddr <- originateManagedLedger
+      fwd <- originateSpecializedForwarder $ toAddress tokenAddr
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      withSender masterAddress . lCallDef tokenAddr $
+          ML.Mint
+          ( #to .! toAddress fwd
+          , #value .! amount
+          )
+      lCallDef fwd amount
+      lCallEP tokenAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]
+
+  it "Successfully forwards DS Tokens to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      dsAddr <- originateDSToken
+      fwd <- originateSpecializedForwarder $ toAddress dsAddr
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      registerInvestor dsAddr investor1 $
+          [(toAddress fwd), centralWallet]
+      mint dsAddr (toAddress fwd) amount
+      lCallDef fwd amount
+      lCallEP dsAddr (Call @"GetBalance") (mkView (#owner .! centralWallet) consumer)
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]

--- a/test/Tree.hs
+++ b/test/Tree.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display -optF --generated-module -optF Tree #-}


### PR DESCRIPTION
Done minus doc type family injectivity "bug" in `morley`:

```haskell
/Users/michaelklein/Coding/forwarder-contract/app/Main.hs:1:1: error:
    Type family equations violate injectivity annotation:
      L.DocItemPosition
        Lorentz.Contracts.DS.V1.Trust.Impl.DRequireRole = 52
        -- Defined in 'Lorentz.Contracts.ManagedLedger.Doc'
      L.DocItemPosition
        Lorentz.Contracts.ManagedLedger.Doc.DRequireRole = 52
        -- Defined in 'Lorentz.Contracts.ManagedLedger.Doc'
  |
1 | -- {-# LANGUAGE NoImplicitPrelude #-}
```