### PR TITLE
[DSP-116] Add forwarder tests

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -65,7 +65,6 @@ import qualified Lorentz.Contracts.Forwarder.DS.V1.Validated as Validated
 import qualified Lorentz.Contracts.Forwarder.DS.V1 as DS
 import qualified Lorentz.Contracts.DS.V1 as DSToken
 import Lorentz.Contracts.DS.V1.Registry.Types (InvestorId(..))
-import qualified Lorentz.Contracts.ManagedLedger as ManagedLedger
 
 import Lorentz.Contracts.View
 import qualified Lorentz.Contracts.Product as Product
@@ -126,7 +125,7 @@ parseTimestamp name =
 data CmdLnArgs
   = Print !(Maybe FilePath) !Bool
   | PrintSpecialized !Address !(L.FutureContract DSToken.Parameter) !(Maybe FilePath) !Bool
-  | PrintSpecializedFA12 !Address !(L.FutureContract ManagedLedger.Parameter) !(Maybe FilePath) !Bool
+  | PrintSpecializedFA12 !Address !Address !(Maybe FilePath) !Bool
   | PrintValidatedExpiring !Address !(L.FutureContract DSToken.Parameter) !(Maybe FilePath) !Bool
   | PrintValidated !Address !(L.FutureContract DSToken.Parameter) !(Maybe FilePath) !Bool
   | InitialStorage !Address !Address !(Maybe FilePath)
@@ -181,18 +180,18 @@ argParser = Opt.subparser $ mconcat
       (Print <$> outputOption <*> onelineOption)
       "Dump DS Token Forwarder contract in the form of Michelson code"
 
-    printSpecializedSubCmd =
+    printSpecializedFA12SubCmd =
       mkCommandParser "print-specialized-fa12"
-      (PrintSpecialized <$>
+      (PrintSpecializedFA12 <$>
         parseAddress "central-wallet" "Address of central wallet" <*>
-        (toFutureDSToken <$> parseAddress "fa12-address" "Address of FA1.2 Token contract") <*>
+        parseAddress "fa12-address" "Address of FA1.2 Token contract" <*>
         outputOption <*>
         onelineOption
       )
       ("Dump FA1.2 Token Forwarder contract, specialized to paricular addresses, " <>
       "in the form of Michelson code")
 
-    printSpecializedFA12SubCmd =
+    printSpecializedSubCmd =
       mkCommandParser "print-specialized"
       (PrintSpecialized <$>
         parseAddress "central-wallet" "Address of central wallet" <*>
@@ -425,12 +424,12 @@ main = do
             forceOneline $
             DS.specializedForwarderContract centralWalletAddr' $
             L.toContractRef dsTokenContractRef'
-      PrintSpecializedFA12 centralWalletAddr' fa12ContractRef' mOutput forceOneline ->
+      PrintSpecializedFA12 centralWalletAddr' fa12ContractAddr' mOutput forceOneline ->
         writeFunc mOutput $
           L.printLorentzContract
             forceOneline $
             Specialized.specializedForwarderContract centralWalletAddr' $
-            L.toContractRef fa12ContractRef'
+            fa12ContractAddr'
       PrintValidatedExpiring centralWalletAddr' dsTokenContractRef' mOutput forceOneline ->
         writeFunc mOutput $
           L.printLorentzContract

--- a/app/NettestHelpers.hs
+++ b/app/NettestHelpers.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module NettestHelpers
+  ( genContractId
+  , originateDS
+  , originateForwarder
+  ) where
+
+import Prelude hiding (putStrLn, show, print)
+
+import Control.Monad (forM_)
+import Fmt (pretty)
+import System.Random (randomRIO)
+import Universum.Print
+import Universum.String
+
+import Lorentz (mt, Text, Address)
+import qualified Lorentz as L
+import Lorentz.Contracts.DS.Permanent (mkEmptyStorage)
+import Lorentz.Contracts.DS.Preprocess (v0Contract, v1CompiledMigration, v1UpgradeParameters)
+import qualified Lorentz.Contracts.DS.V1 as V1
+import qualified Lorentz.Contracts.DS.V1.Token as Token
+import qualified Lorentz.Contracts.Forwarder.Specialized as Fwd
+import qualified Lorentz.Contracts.Upgradeable.Common as Upg
+import Morley.Nettest
+  (AddrOrAlias(..), NettestClientConfig(..), NettestScenario, NettestT, OriginateData(..))
+import qualified Morley.Nettest as NT
+
+genContractId :: Text -> IO Text
+genContractId prefix = do
+  contractIdNum <- randomRIO @Int (1, 10000)
+  return (prefix <> show contractIdNum)
+
+mkProductionOrigParams :: L.Address -> V1.OriginationParameters
+mkProductionOrigParams master = V1.OriginationParameters
+  { opMaster = master
+  , opTokenMeta = Token.TokenMeta
+    { tmName = [mt|DS Token|]
+    , tmSymbol = [mt|DS|]
+    , tmDecimals = 18
+    }
+  , opComplianceInfo = V1.productionComplianceInfo
+  , opMaxLocksPerInvestor = 100
+  }
+
+originateDS :: Monad m => Text -> NettestT m Address
+originateDS contractId = do
+  master <- NT.resolveNettestAddr
+  let origParameters = mkProductionOrigParams master
+
+  contract <- NT.originate OriginateData
+    { odFrom = AddrResolved master
+    , odName = contractId
+    , odBalance = 0
+    , odStorage = mkEmptyStorage master
+    , odContract = v0Contract
+    }
+  forM_ (Upg.makeEpwUpgrade $ v1UpgradeParameters origParameters) $
+    NT.callFrom (AddrResolved master) (AddrResolved contract) L.DefEpName
+  NT.comment $
+    "Successfully deployed DSToken: " <>
+    pretty contractId <> " / " <> pretty contract
+  return contract
+
+originateForwarder
+  :: Monad m => Text -> Address -> Address -> NettestT m Address
+originateForwarder contractId ds centralWallet = do
+  master <- NT.resolveNettestAddr
+  contract <- NT.originate OriginateData
+    { odFrom = AddrResolved master
+    , odName = contractId
+    , odBalance = 0
+    , odStorage = ()
+    , odContract = Fwd.specializedForwarderContract centralWallet ds
+    }
+  NT.comment $
+    "Successfully deployed forwarder: " <>
+    pretty contractId <> " / " <> pretty contract
+  return contract
+ 
+

--- a/package.yaml
+++ b/package.yaml
@@ -27,10 +27,12 @@ dependencies:
 - text
 - constraints
 - morley-ledgers
+- morley-nettest
 - morley-upgradeable
 - constraints
 - containers
 - morley-dstoken
+- universum
 - vinyl
 
 library:
@@ -49,8 +51,10 @@ executables:
     - morley
     # - morley-prelude
     - morley-dstoken
+    - morley-nettest
     - fmt
     - optparse-applicative
+    - random
     - universum
 
 tests:

--- a/package.yaml
+++ b/package.yaml
@@ -63,3 +63,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - prototype-forwarder-contract
+    - fmt
+    - hspec
+    - tasty
+    - tasty-hspec

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7e30c470a1d65efa1256ed64e1f17d328d04582cc589a546ddfb4e28553e2026
+-- hash: 066fb9df50eefcd3f5da3eed5078304ef8808c82ce252d19f1285c6894d8a4f7
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -35,6 +35,7 @@ library
       Lorentz.Contracts.Forwarder.DS.V1.Validated
       Lorentz.Contracts.Forwarder.DS.V1.ValidatedExpiring
       Lorentz.Contracts.Forwarder.Specialized
+      Lorentz.Contracts.Forwarder.TestScenario
       Lorentz.Contracts.Product
       Lorentz.Contracts.Validate.Reception
       Lorentz.Contracts.View
@@ -49,16 +50,19 @@ library
     , morley
     , morley-dstoken
     , morley-ledgers
+    , morley-nettest
     , morley-upgradeable
     , named
     , singletons
     , text
+    , universum
     , vinyl
   default-language: Haskell2010
 
 executable dstoken-forwarder-contract
   main-is: Main.hs
   other-modules:
+      NettestHelpers
       Paths_prototype_forwarder_contract
   hs-source-dirs:
       app
@@ -71,10 +75,12 @@ executable dstoken-forwarder-contract
     , morley
     , morley-dstoken
     , morley-ledgers
+    , morley-nettest
     , morley-upgradeable
     , named
     , optparse-applicative
     , prototype-forwarder-contract
+    , random
     , singletons
     , text
     , universum
@@ -103,6 +109,7 @@ test-suite prototype-forwarder-contract-test
     , morley
     , morley-dstoken
     , morley-ledgers
+    , morley-nettest
     , morley-upgradeable
     , named
     , prototype-forwarder-contract
@@ -110,5 +117,6 @@ test-suite prototype-forwarder-contract-test
     , tasty
     , tasty-hspec
     , text
+    , universum
     , vinyl
   default-language: Haskell2010

--- a/prototype-forwarder-contract.cabal
+++ b/prototype-forwarder-contract.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 91102c0c1b5c7f0b214829250e846b2794b819103ae6e3bfbb7096cc6e9aecb6
+-- hash: 7e30c470a1d65efa1256ed64e1f17d328d04582cc589a546ddfb4e28553e2026
 
 name:           prototype-forwarder-contract
 version:        0.1.0.0
@@ -85,6 +85,11 @@ test-suite prototype-forwarder-contract-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.Lorentz.Contracts.Forwarder.Common
+      Test.Lorentz.Contracts.Forwarder.DS
+      Test.Lorentz.Contracts.Forwarder.DS.Common
+      Test.Lorentz.Contracts.Forwarder.Specialized
+      Tree
       Paths_prototype_forwarder_contract
   hs-source-dirs:
       test
@@ -93,6 +98,8 @@ test-suite prototype-forwarder-contract-test
       base >=4.7 && <5
     , constraints
     , containers
+    , fmt
+    , hspec
     , morley
     , morley-dstoken
     , morley-ledgers
@@ -100,6 +107,8 @@ test-suite prototype-forwarder-contract-test
     , named
     , prototype-forwarder-contract
     , singletons
+    , tasty
+    , tasty-hspec
     , text
     , vinyl
   default-language: Haskell2010

--- a/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
+++ b/src/Lorentz/Contracts/Forwarder/DS/V1/Specialized.hs
@@ -53,7 +53,7 @@ runSpecializedTransfer centralWalletAddr' (ContractRef contractAddr' _) = do
   toTransferParameter
   dip $ do
     push contractAddr'
-    contract @DS.Parameter
+    contractCalling @DS.Parameter $ Call @"Run"
     ifNone
       (failUnexpected (mkMTextUnsafe "not DS"))
       (push (toEnum 0 :: Mutez))

--- a/src/Lorentz/Contracts/Forwarder/TestScenario.hs
+++ b/src/Lorentz/Contracts/Forwarder/TestScenario.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumDecimals #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Lorentz.Contracts.Forwarder.TestScenario
+  ( runTestScenario
+  , TestScenarioParameters(..)
+  ) where
+
+import GHC.TypeLits (KnownSymbol)
+import Universum (safeHead, (?:))
+
+import qualified Lorentz as L
+import Lorentz.Constraints
+import qualified Lorentz.Contracts.DS.V1 as V1
+import Lorentz.Contracts.DS.V1.Compliance.Types
+import qualified Lorentz.Contracts.DS.V1.Token as Token
+import qualified Lorentz.Contracts.DS.V1.Registry as Registry
+import Lorentz.Contracts.DS.V1.Registry.Types
+import Lorentz.Contracts.Upgradeable.Common as Upg
+import Lorentz.Value (Label)
+import Morley.Nettest (AddrOrAlias(..), NettestT)
+import Michelson.Text (mt)
+import qualified Morley.Nettest as NT
+import Tezos.Address (Address)
+import Tezos.Core
+
+inv0, inv1 :: InvestorId
+inv0 = InvestorId [mt|r1|]
+inv1 = InvestorId [mt|r2|]
+
+country0, euCountry :: Country
+country0 = Country [mt|country|]
+euCountry = safeHead euCountries ?: error "no EU countries"
+
+attrInfo0 :: AttributeInfo
+attrInfo0 = AttributeInfo AttrStatApproved Nothing Nothing
+
+mint :: WalletId -> L.Natural -> Token.ParameterMint
+mint wallet val =
+  Token.Mint (Token.mintParamSimple wallet val, Token.CommitRun)
+
+burn :: WalletId -> L.Natural -> Token.ParameterBurn
+burn wallet val =
+  Token.Burn (Token.burnParamSimple wallet val, Token.CommitRun)
+
+
+-- | Required for achieveing worst-case gas consumption for @transfer@.
+-- This does not include 'ciForceAccredited' enabling
+ciMostChecksForTransfer :: SetComplianceInfoData
+ciMostChecksForTransfer = ComplianceInfoExt
+  { ciTotalInvestorLimit = Just $ MaybeInfinity 999
+  , ciMinUSTokens = Nothing
+  , ciMinEUTokens = Nothing
+  , ciUSInvestorLimit = Just $ MaybeInfinity 999
+  , ciUSAccreditedInvestorsLimit = Just $ MaybeInfinity 999
+  , ciNonAccreditedInvestorsLimit = Just $ MaybeInfinity 999
+  , ciMaxUSInvestorPercentage = Nothing
+  , ciFlowbackBlockExpiryDate = Just $ MaybeInfinity farFuture
+  , ciUSLockPeriod = Nothing
+  , ciNonUSLockPeriod = Nothing
+  , ciMinimumTotalInvestors = Nothing
+  , ciMinimumHoldingsPerInvestor = Nothing
+  , ciMaximumHoldingsPerInvestor = Just $ MaybeInfinity 10e18
+  , ciEURetailLimit = Just $ MaybeInfinity 999
+  , ciForceFullTransfer = Just True
+  , ciForceAccredited = Just True
+  , ciForceAccreditedUS = Just True
+  }
+
+mkRun
+  :: ( KnownSymbol name
+     , NicePackedValue arg
+     , L.LookupEntryPoint name (Upg.VerInterface ver) ~ arg
+     , L.RequireUniqueEntryPoints (Upg.VerInterface ver)
+     )
+  => Label name -> arg -> Upg.Parameter ver
+mkRun name arg = Upg.Run $ L.mkUParam name arg
+
+mkRunV1
+  :: ( KnownSymbol name
+     , NicePackedValue arg
+     , L.LookupEntryPoint name (Upg.VerInterface ver) ~ arg
+     , ver ~ V1.VersionId1
+     )
+  => Label name -> arg -> Upg.Parameter ver
+mkRunV1 = mkRun
+
+-- | 'NT.TransferData' for the default entrypoint of some contract.
+defCallData
+  :: forall cp. (Show cp, NiceParameterFull cp)
+  => Address -> (Address, cp) -> NT.TransferData
+defCallData contract (from, param) =
+  NT.TransferData
+    { tdFrom = AddrResolved from
+    , tdTo = AddrResolved contract
+    , tdAmount = 0
+    , tdEntrypoint = L.DefEpName
+    , tdParameter = param
+    }
+
+type Scenario = [NT.TransferData]
+
+compileScenario
+  :: forall m. Monad m
+  => NettestT m Scenario -> NettestT m ()
+compileScenario scenarioM = do
+  scenario <- scenarioM
+  mapM_ NT.transfer scenario
+
+data TestScenarioParameters
+  = TestScenarioParameters
+    { tspDSToken :: Address
+    , tspCentralWallet :: Address
+    , tspForwarder :: Address
+    }
+
+testScenario :: Monad m => TestScenarioParameters -> NettestT m Scenario
+testScenario TestScenarioParameters{..} = do
+  master <- NT.resolveNettestAddr
+  someone <- NT.newAddress "addr1"
+
+  let
+    ds = tspDSToken
+    fwd = tspForwarder
+    fwdWallet = WalletId fwd
+    centralWallet = WalletId tspCentralWallet
+
+    forward :: L.Natural -> NT.TransferData
+    forward tokens = defCallData fwd (someone, tokens)
+
+    dsCallData
+      :: (Address, Upg.Parameter V1.VersionId1)
+      -> NT.TransferData
+    dsCallData = defCallData ds
+
+    performTransfer :: Scenario
+    performTransfer =
+      let tokens = 10e15 in
+      [ dsCallData (master, mkRunV1 #callTokenMint (mint fwdWallet tokens))
+      , forward tokens
+      , dsCallData (master, mkRunV1 #callTokenBurn (burn centralWallet tokens))
+      ]
+
+    initRegistryMinimal :: Scenario
+    initRegistryMinimal =
+      map dsCallData
+      [ (master, mkRunV1 #callRegistry (Registry.RegisterInvestor inv0))
+      , (master, mkRunV1 #callRegistry (Registry.AddWallet (inv0, fwdWallet)))
+      , (master, mkRunV1 #callRegistry (Registry.RegisterInvestor inv1))
+      , (master, mkRunV1 #callRegistry (Registry.AddWallet (inv1, centralWallet)))
+      ]
+
+  pure $ mconcat
+    [ initRegistryMinimal
+    , performTransfer
+    ]
+
+runTestScenario
+  :: Monad m
+  => TestScenarioParameters -> NettestT m ()
+runTestScenario params = compileScenario $ testScenario params

--- a/src/Lorentz/Contracts/View.hs
+++ b/src/Lorentz/Contracts/View.hs
@@ -26,7 +26,7 @@ type View_ = View ()
 
 -- | Construct a `View_`
 toView_ :: ToContractRef r a => a -> View_ r
-toView_ = View () . toContractRef
+toView_ = mkView ()
 
 -- | `view_` specialized to `View_`
 viewUnit_ :: NiceParameter r =>
@@ -38,15 +38,15 @@ viewUnit_ f = do
     f
 
 -- | Uses `parseAddress` with the remainder of the input
-instance Read Address where
+instance Read (TAddress r) where
   readPrec = do
     eAddress <- parseAddress . fromString <$> look
     case eAddress of
       Left err -> fail $ show err
-      Right address' -> return address'
+      Right address' -> return $ toTAddress address'
 
 -- | Uses `readBinaryWith`
-instance (Read a, NiceParameter r) => Read (View a r) where
+instance (Read a, NiceParameter r, ToContractRef r (TAddress r)) => Read (View a r) where
   readPrec = readBinaryWith readPrec readPrec "View" $
-    (\x -> View x . toContractRef @r @Address)
+    (\x -> View x . toContractRef @r @(TAddress r))
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    13dc88b9f17172cfde87b60fa945aada21047a9b # martoon/#65-doc-collision
+    34c9cbfa160cde0ac8e9bd92d8fc57b3844da41e # master
   subdirs:
     - .
     - prelude
@@ -31,9 +31,9 @@ extra-deps:
   commit: ab4345eabd58fc6f05d3b46bea2c5acdba3ec6f8
 
 - git:
-    git@github.com:tqtezos/morley-dstoken.git
+    git@gitlab.com:elevated-returns/morley-dstoken.git
   commit:
-    935ca03370ace435222eb3cd32402ee478b44d74 # master
+    dbfc4980249410a0df1c8c5bdf3d1dd0765d70d3 # master
   subdirs:
     - .
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,12 @@
+module Main
+  ( main
+  ) where
+
+import Test.Tasty (defaultMainWithIngredients)
+
+import Util.Test.Ingredients (ourIngredients)
+
+import Tree (tests)
+
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = tests >>= defaultMainWithIngredients ourIngredients

--- a/test/Test/Lorentz/Contracts/Forwarder/Common.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/Common.hs
@@ -1,0 +1,16 @@
+module Test.Lorentz.Contracts.Forwarder.Common
+  ( centralWallet
+  , masterAddress
+  ) where
+
+
+import Lorentz
+
+import Lorentz.Test
+
+-- | By default, we set master and admin to this address.
+masterAddress :: Address
+masterAddress = genesisAddress
+
+centralWallet :: Address
+centralWallet = genesisAddress2

--- a/test/Test/Lorentz/Contracts/Forwarder/DS.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/DS.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Lorentz.Contracts.Forwarder.DS
+  ( spec_SpecializedDSForwarder
+  , spec_ValidatedDSForwarder
+  ) where
+
+import Lorentz
+
+import Control.Monad (forM_)
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Fmt (Buildable(..), listF)
+
+import Lorentz.Contracts.DS.V1.Registry (InvestorId)
+import qualified Lorentz.Contracts.Forwarder.DS.V1.Specialized as Fwd
+import qualified Lorentz.Contracts.Forwarder.DS.V1.Validated as Validated
+import Lorentz.Contracts.Validate.Reception (Parameter(..), Whitelist)
+import Lorentz.Contracts.Product ((:|:)(..))
+import Lorentz.Test
+import Test.Hspec (Spec, describe, it)
+import Util.Named ((.!))
+
+import Test.Lorentz.Contracts.Forwarder.Common
+import Test.Lorentz.Contracts.Forwarder.DS.Common
+
+type ForwarderRef = TAddress Natural
+type ValidatedForwarderRef = TAddress Validated.Parameter
+
+originateSpecializedForwarder :: DSRef -> IntegrationalScenarioM (ForwarderRef)
+originateSpecializedForwarder dsRef =
+  lOriginate fwd "DS Specialized Forwarder" () (toMutez 0)
+  where
+    fwd = Fwd.specializedForwarderContract centralWallet (callingDefTAddress dsRef)
+
+originateValidatedForwarder
+  :: DSRef -> [InvestorId] -> IntegrationalScenarioM (ValidatedForwarderRef)
+originateValidatedForwarder dsRef investorList =
+  lOriginate fwd "DS Validated Forwarder" storage (toMutez 0)
+  where
+    storage = Validated.mkStorage investorList
+    fwd = Validated.validatedForwarderContract centralWallet (callingDefTAddress dsRef)
+
+spec_SpecializedDSForwarder :: Spec
+spec_SpecializedDSForwarder = do
+  it "Successfully forwards funds to centralWallet" $
+    integrationalTestExpectation $ do
+      dsAddr <- originateDSToken
+      fwd <- originateSpecializedForwarder dsAddr
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      registerInvestor dsAddr investor1 $
+          [(toAddress fwd), centralWallet]
+      mint dsAddr (toAddress fwd) 100500
+      lCallDef fwd (100500 :: Natural)
+      lCallEP dsAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [100500]
+
+spec_ValidatedDSForwarder :: Spec
+spec_ValidatedDSForwarder = do
+  it "Successfully forwards funds to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr [investor1]
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      registerInvestor dsAddr investor1 $
+          [(toAddress fwd), centralWallet]
+      mint dsAddr (toAddress fwd) amount
+      lCallDef fwd $ LeftParameter amount
+      lCallEP dsAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]
+
+  it "Successfully validates a whitelisted investor" $
+    integrationalTestExpectation $ do
+      let investors = [investor1, investor2]
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr investors
+      forM_ investors $ \inv ->
+        lCallDef fwd . RightParameter $ Validate inv
+      validate . Right $ expectAnySuccess
+
+  it "Fails to validate a non-whitelisted investor" $
+    integrationalTestExpectation $ do
+      let investors = [investor1, investor2]
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr investors
+      lCallDef fwd . RightParameter $ Validate investor3
+      validate . Left $ lExpectError (== [mt|not in whitelist|])
+
+  it "Returns a list of whitelisted investors" $
+    integrationalTestExpectation $ do
+      let investors = [investor1, investor2]
+      dsAddr <- originateDSToken
+      fwd <- originateValidatedForwarder dsAddr investors
+      consumer <- lOriginateEmpty @Whitelist contractConsumer "consumer"
+      lCallDef fwd . RightParameter . GetWhitelist $ mkView () consumer
+      validate . Right $
+        lExpectViewConsumerStorage consumer $ [Set.fromList investors]
+
+instance Buildable (Set InvestorId) where
+  build = listF

--- a/test/Test/Lorentz/Contracts/Forwarder/DS/Common.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/DS/Common.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Lorentz.Contracts.Forwarder.DS.Common
+  ( DSRef
+  , investor1
+  , investor2
+  , investor3
+  , mint
+  , originateDSToken
+  , registerInvestor
+  ) where
+
+
+import Control.Monad (forM_)
+import Lorentz
+
+import Data.Coerce (coerce)
+import GHC.TypeLits (KnownSymbol)
+
+import qualified Lorentz.Contracts.DS.Permanent as Permanent
+import Lorentz.Contracts.DS.Preprocess
+import Lorentz.Contracts.DS.V0 as V0
+import Lorentz.Contracts.DS.V1 as V1
+import qualified Lorentz.Contracts.DS.V1.Token as Token
+import Lorentz.Contracts.DS.V1.Registry as Registry
+import qualified Lorentz.Contracts.Upgradeable.Common as Upg
+import Lorentz.Test
+import Lorentz.UParam
+
+import Test.Lorentz.Contracts.Forwarder.Common
+
+investor1, investor2 :: Registry.InvestorId
+investor1 = Registry.InvestorId [mt|investor1|]
+investor2 = Registry.InvestorId [mt|investor2|]
+investor3 = Registry.InvestorId [mt|investor3|]
+
+maxLocksPerInvestorDefault :: Natural
+maxLocksPerInvestorDefault = 100
+
+defaultOrigParameters :: OriginationParameters
+defaultOrigParameters = OriginationParameters
+  { opMaster = masterAddress
+  , opTokenMeta = Token.dummyTokenMeta
+  , opComplianceInfo = weakestComplianceInfo
+  , opMaxLocksPerInvestor = maxLocksPerInvestorDefault
+  }
+
+dsCall
+  :: forall a name.
+  ( NicePackedValue a
+  , KnownSymbol name
+  , RequireUniqueEntryPoints V1.Interface
+  , LookupEntryPoint name V1.Interface ~ a
+  )
+  => Label name
+  -> DSRef
+  -> a
+  -> IntegrationalScenarioM ()
+dsCall method addr arg =
+  lCallDef addr $
+  Upg.Run (mkUParam method arg :: UParam V1.Interface)
+
+-- | 'TAddress' of DS protocol contract (V1).
+type DSRef = TAddress V1.Parameter
+
+-- | Originate V1 of DS Protocol with default parameters.
+originateDSToken :: IntegrationalScenarioM DSRef
+originateDSToken =
+  originateDSTokenWithParameters defaultOrigParameters
+
+-- | Originate V1 of DS Protocol with custom parameters.
+originateDSTokenWithParameters
+  :: OriginationParameters -> IntegrationalScenarioM DSRef
+originateDSTokenWithParameters origParameters = do
+  contract <- lOriginate
+    v0Contract
+    "DS Protocol"
+    (Permanent.mkEmptyStorage masterAddress)
+    (toMutez 0)
+  upgradeToV1 origParameters contract
+
+upgradeToV1 ::
+     OriginationParameters
+  -> TAddress (Upg.Parameter V0.VersionId0)
+  -> IntegrationalScenarioM DSRef
+upgradeToV1 origParameters contract =
+  -- 'coerceContractRef' is necessary because our 'Parameter' is a
+  -- newtype wrapper.
+  coerce <$>
+  Upg.integrationalTestEpwUpgrade (v1UpgradeParameters origParameters) contract
+
+registerInvestor
+    :: DSRef -> InvestorId -> [Address] -> IntegrationalScenarioM ()
+registerInvestor dsRef investor addressList = do
+  withSender masterAddress $
+    dsCall #callRegistry dsRef $ RegisterInvestor investor
+  forM_ addressList $ \address -> do
+    withSender masterAddress $
+      dsCall #callRegistry dsRef $
+        AddWallet (investor, WalletId address)
+
+mint :: DSRef -> Address -> Natural -> IntegrationalScenarioM ()
+mint dsRef beneficiary amount =
+  withSender masterAddress $
+    dsCall #callTokenMint dsRef $
+      Token.Mint (Token.mintParamSimple wallet amount, Token.CommitRun)
+  where wallet = WalletId beneficiary

--- a/test/Test/Lorentz/Contracts/Forwarder/Specialized.hs
+++ b/test/Test/Lorentz/Contracts/Forwarder/Specialized.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Test.Lorentz.Contracts.Forwarder.Specialized
+  ( spec_SpecializedForwarder
+  ) where
+
+import Lorentz
+
+import Control.Monad (forM_)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Fmt (Buildable(..), listF)
+
+import qualified Indigo.Contracts.AbstractLedger as AL
+import qualified Lorentz.Contracts.Spec.AbstractLedgerInterface as AL
+import Lorentz.Contracts.DS.V1.Registry (InvestorId)
+import qualified Lorentz.Contracts.Forwarder.Specialized as Fwd
+import qualified Lorentz.Contracts.ManagedLedger as ML
+import Lorentz.Test
+import Test.Hspec (Spec, describe, it)
+import Util.Named ((.!))
+
+import Test.Lorentz.Contracts.Forwarder.Common
+import Test.Lorentz.Contracts.Forwarder.DS.Common
+
+type ForwarderRef = TAddress Natural
+
+originateSpecializedForwarder :: Address -> IntegrationalScenarioM (ForwarderRef)
+originateSpecializedForwarder tokenAddress =
+  lOriginate fwd "FA1.2 Specialized Forwarder" () (toMutez 0)
+  where
+    fwd = Fwd.specializedForwarderContract centralWallet tokenAddress
+
+originateAbstractLedger :: IntegrationalScenarioM (TAddress AL.Parameter)
+originateAbstractLedger =
+  lOriginate AL.abstractLedgerContract "Abstract ledger" storage (toMutez 0)
+  where
+    storage = AL.Storage
+       { AL.ledger = BigMap $ Map.fromList [(masterAddress, 100500)]
+       , AL.totalSupply = 100500
+       }
+
+originateManagedLedger :: IntegrationalScenarioM (TAddress ML.Parameter)
+originateManagedLedger =
+  lOriginate ML.managedLedgerContract "Managed ledger"
+    (ML.mkStorage masterAddress mempty) (toMutez 0)
+
+spec_SpecializedForwarder :: Spec
+spec_SpecializedForwarder = do
+  it "Successfully forwards Abstract ledger tokens to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      tokenAddr <- originateAbstractLedger
+      fwd <- originateSpecializedForwarder $ toAddress tokenAddr
+      withSender masterAddress . lCallDef tokenAddr $
+          AL.Transfer
+          ( #from .! masterAddress
+          , #to .! toAddress fwd
+          , #value .! amount
+          )
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      lCallDef fwd amount
+      lCallEP tokenAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]
+
+  it "Successfully forwards Managed ledger tokens to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      tokenAddr <- originateManagedLedger
+      fwd <- originateSpecializedForwarder $ toAddress tokenAddr
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      withSender masterAddress . lCallDef tokenAddr $
+          ML.Mint
+          ( #to .! toAddress fwd
+          , #value .! amount
+          )
+      lCallDef fwd amount
+      lCallEP tokenAddr (Call @"GetBalance") $
+          mkView (#owner .! centralWallet) consumer
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]
+
+  it "Successfully forwards DS Tokens to centralWallet" $
+    integrationalTestExpectation $ do
+      let amount = 100500
+      dsAddr <- originateDSToken
+      fwd <- originateSpecializedForwarder $ toAddress dsAddr
+      consumer <- lOriginateEmpty @Natural contractConsumer "consumer"
+      registerInvestor dsAddr investor1 $
+          [(toAddress fwd), centralWallet]
+      mint dsAddr (toAddress fwd) amount
+      lCallDef fwd amount
+      lCallEP dsAddr (Call @"GetBalance") (mkView (#owner .! centralWallet) consumer)
+      validate . Right $
+          lExpectViewConsumerStorage consumer [amount]

--- a/test/Tree.hs
+++ b/test/Tree.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display -optF --generated-module -optF Tree #-}


### PR DESCRIPTION
Problem: There's a need to have tests for different flavors of the forwarder contract

Solution:
1) Add unit tests for DS specialized, DS validated, FA1.2 specialized.
2) Use the entrypoints feature in forwarders.
3) Use `Address` instead of `ContractRef ManagedLedger.Parameter` FA1.2 forwarder (so that we can use and test the forwarder with any contract, not just ManagedLedger).
4) Add a CLI subcommand to launch a test scenario on a real network (using `morley-nettest`). 